### PR TITLE
Revamp NodeContext

### DIFF
--- a/core/src/main/scala/playground/CompletionProvider.scala
+++ b/core/src/main/scala/playground/CompletionProvider.scala
@@ -11,6 +11,8 @@ import smithy4s.dynamic.DynamicSchemaIndex
 import playground.smithyql.QualifiedIdentifier
 import cats.data.NonEmptyList
 import playground.smithyql.NodeContext
+import playground.smithyql.NodeContext.^^:
+import playground.smithyql.NodeContext.Root
 import playground.smithyql.RangeIndex
 
 trait CompletionProvider {
@@ -110,14 +112,16 @@ object CompletionProvider {
               matchingNode
                 .toList
                 .flatMap {
-                  case NodeContext.OperationContext(_) =>
+                  case NodeContext.PathEntry.AtOperationName ^^: Root =>
                     completeOperationName(serviceId)(
                       q.useClause.map(_.value.identifier)
                     )
 
-                  case NodeContext.InputContext(ctx) =>
+                  case NodeContext.PathEntry.AtOperationInput ^^: ctx =>
                     completionsByEndpoint(serviceId)(q.operationName.value)
-                      .getCompletions(ctx.toList)
+                      .getCompletions(ctx)
+
+                  case _ => Nil
                 }
 
             case None =>

--- a/core/src/main/scala/playground/smithyql/CompletionVisitor.scala
+++ b/core/src/main/scala/playground/smithyql/CompletionVisitor.scala
@@ -32,9 +32,11 @@ import smithy4s.schema.SchemaVisitor
 import NodeContext.PathEntry
 import java.util.UUID
 import smithy.api
+import NodeContext.^^:
+import NodeContext.Root
 
 trait CompletionResolver[+A] {
-  def getCompletions(ctx: List[PathEntry]): List[CompletionItem]
+  def getCompletions(ctx: NodeContext): List[CompletionItem]
   def retag[B]: CompletionResolver[B] = getCompletions(_)
 }
 
@@ -292,9 +294,9 @@ object CompletionVisitor extends SchemaVisitor[CompletionResolver] {
   private def quoteAware[A](
     makeCompletion: (String => String) => List[CompletionItem]
   ): CompletionResolver[A] = {
-    case PathEntry.Quotes :: Nil => makeCompletion(identity)
-    case Nil                     => makeCompletion(TextUtils.quote)
-    case _                       => Nil
+    case PathEntry.Quotes ^^: Root => makeCompletion(identity)
+    case Root                      => makeCompletion(TextUtils.quote)
+    case _                         => Nil
   }
 
   override def primitive[P](
@@ -345,8 +347,8 @@ object CompletionVisitor extends SchemaVisitor[CompletionResolver] {
     val memberInstance = member.compile(this)
 
     {
-      case PathEntry.CollectionEntry(_) :: rest => memberInstance.getCompletions(rest)
-      case _                                    =>
+      case PathEntry.CollectionEntry(_) ^^: rest => memberInstance.getCompletions(rest)
+      case _                                     =>
         // other contexts are invalid
         Nil
     }
@@ -362,7 +364,7 @@ object CompletionVisitor extends SchemaVisitor[CompletionResolver] {
     val fv = value.compile(this)
 
     structLike(
-      inBody = fk.getCompletions(Nil).map { item =>
+      inBody = fk.getCompletions(NodeContext.Root).map { item =>
         item.asValueCompletion
       },
       inValue = (_, t) => fv.getCompletions(t),
@@ -388,11 +390,11 @@ object CompletionVisitor extends SchemaVisitor[CompletionResolver] {
 
   private def structLike[S](
     inBody: List[CompletionItem],
-    inValue: (String, List[PathEntry]) => List[CompletionItem],
+    inValue: (String, NodeContext) => List[CompletionItem],
   ): CompletionResolver[S] = {
-    case PathEntry.StructBody :: Nil                              => inBody
-    case PathEntry.StructBody :: PathEntry.StructValue(h) :: rest => inValue(h, rest)
-    case _                                                        => Nil
+    case PathEntry.StructBody ^^: Root                              => inBody
+    case PathEntry.StructBody ^^: PathEntry.StructValue(h) ^^: rest => inValue(h, rest)
+    case _                                                          => Nil
   }
 
   override def struct[S](

--- a/core/src/main/scala/playground/smithyql/NodeContext.scala
+++ b/core/src/main/scala/playground/smithyql/NodeContext.scala
@@ -2,56 +2,94 @@ package playground.smithyql
 
 import cats.implicits._
 import cats.data.Chain
+import cats.data.Chain.==:
 
 // The path to a position in the parsed source
-sealed trait NodeContext extends Product with Serializable {
-  def render: String
+sealed trait NodeContext extends Product with Serializable with NodeContext.PathEntry.TraversalOps {
+
+  def render: String =
+    this match {
+      case NodeContext.Impl(context) =>
+        import NodeContext.PathEntry._
+
+        context
+          .map {
+            case AtOperationName    => ".operationName"
+            case AtOperationInput   => ".input"
+            case CollectionEntry(i) => s".[${i.getOrElse("")}]"
+            case StructValue(key)   => s".$key"
+            case StructBody         => ".{}"
+            case Quotes             => ".\"\""
+          }
+          .mkString_(".input", "", "")
+
+    }
+
+  def append(elem: NodeContext.PathEntry): NodeContext =
+    this match {
+      case NodeContext.Impl(context) => NodeContext.Impl(context.append(elem))
+    }
 
   def length: Long =
     this match {
-      case NodeContext.OperationContext(_)   => 1
-      case NodeContext.InputContext(context) => 1 + context.size
+      case NodeContext.Impl(context) => context.size
+    }
+
+  def toList: List[NodeContext.PathEntry] =
+    this match {
+      case NodeContext.Impl(ctx) => ctx.toList
+    }
+
+  def uncons: Option[(NodeContext.PathEntry, NodeContext)] =
+    this match {
+      case NodeContext.Impl(h ==: t) => Some((h, NodeContext.Impl(t)))
+      case _                         => None
+    }
+
+  def ^^:(item: NodeContext.PathEntry): NodeContext =
+    this match {
+      case NodeContext.Impl(context) => NodeContext.Impl(context.prepend(item))
     }
 
 }
 
 object NodeContext {
 
-  final case class OperationContext(opName: WithSource[OperationName]) extends NodeContext {
-    def render: String = ".operationName"
+  object ^^: {
+    def unapply(items: NodeContext): Option[(PathEntry, NodeContext)] = items.uncons
   }
 
-  final case class InputContext(context: Chain[PathEntry]) extends NodeContext {
-    def append(elem: PathEntry) = copy(context.append(elem))
+  val Root: NodeContext = Impl(Chain.nil)
 
-    def toList = context.toList
-
-    def render: String = {
-      import PathEntry._
-      context
-        .map {
-          case CollectionEntry(i) => s".[${i.getOrElse("")}]"
-          case StructValue(key)   => s".$key"
-          case StructBody         => ".{}"
-          case Quotes             => ".\"\""
-        }
-        .mkString_(".input", "", "")
-    }
-
-  }
-
-  object InputContext {
-    val root: InputContext = InputContext(Chain.nil)
-  }
+  private final case class Impl(context: Chain[PathEntry]) extends NodeContext
 
   sealed trait PathEntry extends Product with Serializable
 
   object PathEntry {
+    case object AtOperationName extends PathEntry
+    case object AtOperationInput extends PathEntry
     final case class StructValue(key: String) extends PathEntry
     // no index if it's not in an entry - todo replace with CollectionBody?
     final case class CollectionEntry(index: Option[Int]) extends PathEntry
     case object StructBody extends PathEntry
     case object Quotes extends PathEntry
+
+    trait TraversalOps {
+      self: NodeContext =>
+
+      def inOperationName: NodeContext = append(NodeContext.PathEntry.AtOperationName)
+      def inOperationInput: NodeContext = append(NodeContext.PathEntry.AtOperationInput)
+      def inStructValue(key: String): NodeContext = append(NodeContext.PathEntry.StructValue(key))
+
+      def inCollectionEntry(index: Option[Int]): NodeContext = append(
+        NodeContext.PathEntry.CollectionEntry(index)
+      )
+
+      def inStructBody: NodeContext = append(NodeContext.PathEntry.StructBody)
+      def inQuotes: NodeContext = append(NodeContext.PathEntry.Quotes)
+
+    }
+
   }
 
 }

--- a/core/src/test/scala/playground/smithyql/AtPositionTests.scala
+++ b/core/src/test/scala/playground/smithyql/AtPositionTests.scala
@@ -1,8 +1,6 @@
 package playground.smithyql
 
 import weaver._
-import cats.data.Chain
-import NodeContext.PathEntry._
 
 object AtPositionTests extends FunSuite {
 
@@ -40,13 +38,11 @@ object AtPositionTests extends FunSuite {
     assert(
       actual == Some(
         NodeContext
-          .InputContext(
-            Chain(
-              StructBody,
-              StructValue("root"),
-              StructBody,
-            )
-          )
+          .Root
+          .inOperationInput
+          .inStructBody
+          .inStructValue("root")
+          .inStructBody
       )
     )
   }
@@ -59,15 +55,13 @@ object AtPositionTests extends FunSuite {
     assert(
       actual == Some(
         NodeContext
-          .InputContext(
-            Chain(
-              StructBody,
-              StructValue("root"),
-              StructBody,
-              StructValue("mid"),
-              StructBody,
-            )
-          )
+          .Root
+          .inOperationInput
+          .inStructBody
+          .inStructValue("root")
+          .inStructBody
+          .inStructValue("mid")
+          .inStructBody
       )
     )
   }
@@ -77,19 +71,9 @@ object AtPositionTests extends FunSuite {
       s"""Operat${CURSOR}ion { root = { mid = { child = "hello", }, }, }"""
     )
 
-    val op = WithSource(
-      commentsLeft = Nil,
-      commentsRight = Nil,
-      range = SourceRange(Position(0), Position("Operation".length)),
-      value = OperationName("Operation"),
-    )
-
     assert(
       actual == Some(
-        NodeContext
-          .OperationContext(
-            op
-          )
+        NodeContext.Root.inOperationName
       )
     )
   }
@@ -99,12 +83,7 @@ object AtPositionTests extends FunSuite {
       s"""Operation { root = ${CURSOR}[ { mid = { inner = "hello", }, } ],  }"""
     )
 
-    val expected = NodeContext.InputContext(
-      Chain(
-        StructBody,
-        StructValue("root"),
-      )
-    )
+    val expected = NodeContext.Root.inOperationInput.inStructBody.inStructValue("root")
 
     assert(
       actual == Some(
@@ -119,13 +98,11 @@ object AtPositionTests extends FunSuite {
     )
 
     val expected = NodeContext
-      .InputContext(
-        Chain(
-          StructBody,
-          StructValue("root"),
-          CollectionEntry(None),
-        )
-      )
+      .Root
+      .inOperationInput
+      .inStructBody
+      .inStructValue("root")
+      .inCollectionEntry(None)
 
     assert(
       actual == Some(
@@ -139,15 +116,14 @@ object AtPositionTests extends FunSuite {
       s"""Operation { root = [ { ${CURSOR} mid = { inner = "hello", }, } ],  }"""
     )
 
-    val expected = NodeContext
-      .InputContext(
-        Chain(
-          StructBody,
-          StructValue("root"),
-          CollectionEntry(Some(0)),
-          StructBody,
-        )
-      )
+    val expected =
+      NodeContext
+        .Root
+        .inOperationInput
+        .inStructBody
+        .inStructValue("root")
+        .inCollectionEntry(Some(0))
+        .inStructBody
     assert(actual == Some(expected))
   }
 
@@ -159,16 +135,14 @@ object AtPositionTests extends FunSuite {
     assert(
       actual == Some(
         NodeContext
-          .InputContext(
-            Chain(
-              StructBody,
-              StructValue("root"),
-              CollectionEntry(Some(1)),
-              StructBody,
-              StructValue("mid"),
-              StructBody,
-            )
-          )
+          .Root
+          .inOperationInput
+          .inStructBody
+          .inStructValue("root")
+          .inCollectionEntry(Some(1))
+          .inStructBody
+          .inStructValue("mid")
+          .inStructBody
       )
     )
   }
@@ -180,13 +154,7 @@ object AtPositionTests extends FunSuite {
 
     assert(
       actual == Some(
-        NodeContext
-          .InputContext(
-            Chain(
-              StructBody,
-              StructValue("root"),
-            )
-          )
+        NodeContext.Root.inOperationInput.inStructBody.inStructValue("root")
       )
     )
   }
@@ -198,14 +166,7 @@ object AtPositionTests extends FunSuite {
 
     assert(
       actual == Some(
-        NodeContext
-          .InputContext(
-            Chain(
-              StructBody,
-              StructValue("root"),
-              StructBody,
-            )
-          )
+        NodeContext.Root.inOperationInput.inStructBody.inStructValue("root").inStructBody
       )
     )
   }
@@ -217,13 +178,7 @@ object AtPositionTests extends FunSuite {
 
     assertFound(
       actual,
-      NodeContext
-        .InputContext(
-          Chain(
-            StructBody,
-            StructValue("field"),
-          )
-        ),
+      NodeContext.Root.inOperationInput.inStructBody.inStructValue("field"),
     )
 
   }
@@ -235,14 +190,7 @@ object AtPositionTests extends FunSuite {
 
     assert(
       actual == Some(
-        NodeContext
-          .InputContext(
-            Chain(
-              StructBody,
-              StructValue("field"),
-              Quotes,
-            )
-          )
+        NodeContext.Root.inOperationInput.inStructBody.inStructValue("field").inQuotes
       )
     )
   }

--- a/core/src/test/scala/playground/smithyql/CompletionTests.scala
+++ b/core/src/test/scala/playground/smithyql/CompletionTests.scala
@@ -25,19 +25,19 @@ object CompletionTests extends FunSuite {
 
   def getCompletions(
     schema: Schema[_],
-    ctx: List[NodeContext.PathEntry],
+    ctx: NodeContext,
   ): List[CompletionItem] = schema.compile(CompletionVisitor).getCompletions(ctx)
 
   test("completions on struct are empty without StructBody") {
 
-    val completions = getCompletions(Good.schema, Nil)
+    val completions = getCompletions(Good.schema, NodeContext.Root)
 
     assert(completions.isEmpty)
   }
 
   test("completions on struct include all field names") {
 
-    val completions = getCompletions(Good.schema, List(StructBody))
+    val completions = getCompletions(Good.schema, NodeContext.Root.inStructBody)
 
     val fieldNames = completions.map(_.label)
 
@@ -47,7 +47,7 @@ object CompletionTests extends FunSuite {
 
   test("completions on struct describe the field types") {
 
-    val completions = getCompletions(Good.schema, List(StructBody))
+    val completions = getCompletions(Good.schema, NodeContext.Root.inStructBody)
 
     val results = completions.map { field =>
       (field.label, field.detail)
@@ -59,7 +59,7 @@ object CompletionTests extends FunSuite {
   test("completions on struct add prefix/docs for optional fields") {
     val AnOptionalFieldLabel = "str"
 
-    val completions = getCompletions(HasNewtypes.schema, List(StructBody))
+    val completions = getCompletions(HasNewtypes.schema, NodeContext.Root.inStructBody)
       .filter(_.label == AnOptionalFieldLabel)
 
     val details = completions.map(_.detail)
@@ -71,14 +71,14 @@ object CompletionTests extends FunSuite {
 
   test("completions on union are empty without StructBody") {
 
-    val completions = getCompletions(Hero.schema, Nil)
+    val completions = getCompletions(Hero.schema, NodeContext.Root)
 
     assert(completions.isEmpty)
   }
 
   test("completions on union") {
 
-    val completions = getCompletions(Hero.schema, List(StructBody))
+    val completions = getCompletions(Hero.schema, NodeContext.Root.inStructBody)
 
     val fieldNames = completions.map(_.label)
     val details = completions.map(_.detail)
@@ -90,16 +90,16 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on union case are the same as completions on the underlying structure") {
-    val pathToField = List(StructValue("good"), StructBody)
+    val pathToField = NodeContext.Root.inStructValue("good").inStructBody
 
     val completionsOnAlt = getCompletions(
       Hero.schema,
-      StructBody :: pathToField,
+      StructBody ^^: pathToField,
     ).map(_.label)
 
     val completionsOnStruct = getCompletions(
       Good.schema,
-      StructBody :: Nil,
+      NodeContext.Root.append(StructBody),
     ).map(_.label)
 
     assert.eql(completionsOnAlt, completionsOnStruct)
@@ -108,7 +108,7 @@ object CompletionTests extends FunSuite {
   test("no completions on collection without entry") {
     val completions = getCompletions(
       Schema.list(Good.schema),
-      Nil,
+      NodeContext.Root,
     )
 
     assert(completions.isEmpty)
@@ -117,7 +117,7 @@ object CompletionTests extends FunSuite {
   test("completions on struct in list are available") {
     val completions = getCompletions(
       Schema.list(Good.schema),
-      List(CollectionEntry(Some(0)), StructBody),
+      NodeContext.Root.inCollectionEntry(0.some).inStructBody,
     )
 
     val fieldNames = completions.map(_.label)
@@ -127,7 +127,7 @@ object CompletionTests extends FunSuite {
 
   test("completions on enum without quotes have quotes") {
 
-    val completions = getCompletions(Power.schema, Nil)
+    val completions = getCompletions(Power.schema, NodeContext.Root)
 
     val inserts = completions.map(_.insertText)
     val expectedInserts = List("ICE", "FIRE", "LIGHTNING", "WIND")
@@ -139,7 +139,7 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on enum in quotes don't have quotes") {
-    val completions = getCompletions(Power.schema, List(Quotes))
+    val completions = getCompletions(Power.schema, NodeContext.Root.inQuotes)
 
     val inserts = completions.map(_.insertText)
     val expectedInserts = List("ICE", "FIRE", "LIGHTNING", "WIND")
@@ -150,7 +150,7 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on enum don't have Optional docs") {
-    val completions = getCompletions(Power.schema, List(Quotes))
+    val completions = getCompletions(Power.schema, NodeContext.Root.inQuotes)
 
     val docs = completions.flatMap(_.docs)
 
@@ -158,7 +158,7 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on map keys that are enums") {
-    val completions = getCompletions(PowerMap.schema, List(StructBody))
+    val completions = getCompletions(PowerMap.schema, NodeContext.Root.inStructBody)
 
     val inserts = completions.map(_.insertText)
 
@@ -177,11 +177,7 @@ object CompletionTests extends FunSuite {
           Schema.string,
           Good.schema,
         ),
-      List(
-        StructBody,
-        StructValue("anyKey"),
-        StructBody,
-      ),
+      NodeContext.Root.inStructBody.inStructValue("anyKey").inStructBody,
     )
 
     val fieldNames = completions.map(_.label)
@@ -191,7 +187,7 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on timestamp without quotes have quotes") {
-    val completions = getCompletions(Schema.timestamp, Nil)
+    val completions = getCompletions(Schema.timestamp, NodeContext.Root)
 
     val extractQuote = """\"(.*)\"""".r
 
@@ -209,7 +205,7 @@ object CompletionTests extends FunSuite {
   test("completions on timestamp in quotes don't have quotes") {
     val completions = getCompletions(
       Schema.timestamp,
-      List(Quotes),
+      NodeContext.Root.inQuotes,
     )
 
     val inserts = completions.map(_.insertText).foldMap {
@@ -223,7 +219,7 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on uuid include a random uuid") {
-    val completions = getCompletions(Schema.uuid, List(Quotes))
+    val completions = getCompletions(Schema.uuid, NodeContext.Root.inQuotes)
 
     val inserts = completions.map(_.insertText).foldMap {
       case JustString(value) =>
@@ -239,7 +235,8 @@ object CompletionTests extends FunSuite {
   }
 
   test("completions on deprecated fields have proper hints in docs") {
-    val completions = getCompletions(HasDeprecations.schema, List(StructBody)).filter(_.deprecated)
+    val completions = getCompletions(HasDeprecations.schema, NodeContext.Root.inStructBody)
+      .filter(_.deprecated)
 
     val results = completions.map(c => (c.label, c.docs)).toMap
 

--- a/core/src/test/scala/playground/smithyql/RangeIndexTests.scala
+++ b/core/src/test/scala/playground/smithyql/RangeIndexTests.scala
@@ -19,7 +19,7 @@ object RangeIndexTests extends SimpleIOSuite {
         result == Some(
           ContextRange(
             range = SourceRange(Position("hello {".length), Position(q.length - 1)),
-            ctx = NodeContext.InputContext.root.append(NodeContext.PathEntry.StructBody),
+            ctx = NodeContext.Root.inOperationInput.inStructBody,
           )
         )
       )


### PR DESCRIPTION
Merge `OperationNameContext` into a normal PathEntry. It wasn't worth the effort of having a separate branch of node context.

Also adds some syntax so that we don't deal with plain lists.