### PR TITLE
Improvements to useClause

### DIFF
--- a/core/src/main/scala/playground/CommandResultReporter.scala
+++ b/core/src/main/scala/playground/CommandResultReporter.scala
@@ -72,7 +72,7 @@ object CommandResultReporter {
 
       private def writeOutput(
         node: InputNode[cats.Id]
-      ) = Formatter.writeAst(node.mapK(WithSource.liftId)).renderTrim(80)
+      ) = Formatter.writeInputNode(node.mapK(WithSource.liftId)).renderTrim(80)
 
     }
 

--- a/core/src/main/scala/playground/CompletionProvider.scala
+++ b/core/src/main/scala/playground/CompletionProvider.scala
@@ -114,7 +114,11 @@ object CompletionProvider {
                 .toList
                 .flatMap {
                   case NodeContext.PathEntry.AtUseClause ^^: Root =>
-                    servicesById.map(CompletionItem.useServiceClause.tupled).toList
+                    servicesById
+                      .toList
+                      .sortBy(_._1)
+                      .map(CompletionItem.useServiceClause.tupled)
+                      .toList
 
                   case NodeContext.PathEntry.AtOperationName ^^: Root =>
                     completeOperationName(serviceId)(

--- a/core/src/main/scala/playground/DocumentSymbolProvider.scala
+++ b/core/src/main/scala/playground/DocumentSymbolProvider.scala
@@ -19,16 +19,21 @@ object DocumentSymbolProvider {
           findInOperation(q.operationName, q.input)
     }
 
-  private def findInUseClause(clause: Option[WithSource[UseClause]]): List[DocumentSymbol] =
-    clause.map { useClause =>
-      DocumentSymbol(
-        useClause.value.identifier.render,
-        SymbolKind.Package,
-        useClause.range,
-        useClause.range,
-        Nil,
-      )
-    }.toList
+  private def findInUseClause(
+    clause: WithSource[Option[UseClause[WithSource]]]
+  ): List[DocumentSymbol] =
+    clause
+      .value
+      .map { useClause =>
+        DocumentSymbol(
+          useClause.identifier.value.render,
+          SymbolKind.Package,
+          useClause.identifier.range,
+          useClause.identifier.range,
+          Nil,
+        )
+      }
+      .toList
 
   private def findInOperation(
     op: WithSource[OperationName],

--- a/core/src/main/scala/playground/MultiServiceResolver.scala
+++ b/core/src/main/scala/playground/MultiServiceResolver.scala
@@ -39,9 +39,9 @@ object ResolutionFailure {
 
   // Returns the preferred range for diagnostics about resolution failure
   def diagnosticRange(q: Query[WithSource]): SourceRange =
-    q.useClause match {
+    q.useClause.value match {
       case None         => q.operationName.range
-      case Some(clause) => clause.range
+      case Some(clause) => clause.identifier.range
     }
 
 }

--- a/core/src/main/scala/playground/QueryCompiler.scala
+++ b/core/src/main/scala/playground/QueryCompiler.scala
@@ -176,7 +176,7 @@ sealed trait CompilationErrorDetails extends Product with Serializable {
       case AmbiguousService(matching) =>
         s"""Multiple services are available. Add a use clause to specify the service you want to use.
            |Available services:""".stripMargin + matching
-          .map(UseClause(_))
+          .map(UseClause[Id](_).mapK(WithSource.liftId))
           .map(Formatter.renderUseClause(_).render(Int.MaxValue))
           .mkString_("\n", "\n", ".")
 

--- a/core/src/main/scala/playground/QueryCompiler.scala
+++ b/core/src/main/scala/playground/QueryCompiler.scala
@@ -176,6 +176,7 @@ sealed trait CompilationErrorDetails extends Product with Serializable {
       case AmbiguousService(matching) =>
         s"""Multiple services are available. Add a use clause to specify the service you want to use.
            |Available services:""".stripMargin + matching
+          .sorted
           .map(UseClause[Id](_).mapK(WithSource.liftId))
           .map(Formatter.renderUseClause(_).render(Int.MaxValue))
           .mkString_("\n", "\n", ".")

--- a/core/src/main/scala/playground/run.scala
+++ b/core/src/main/scala/playground/run.scala
@@ -167,7 +167,7 @@ private class MultiServiceCompiler[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]](
   private def getService(
     q: Query[WithSource]
   ): Either[Throwable, Compiler[Ior[Throwable, *]]] = MultiServiceResolver
-    .resolveService(q.useClause.map(_.value.identifier), services)
+    .resolveService(q.useClause.value.map(_.identifier.value), services)
     .leftMap { rf =>
       CompilationFailed.one(
         CompilationError.error(
@@ -277,14 +277,14 @@ object Runner {
     new Optional[F] {
       def get(q: Query[WithSource]): IorNel[Issue, Runner[F]] = MultiServiceResolver
         .resolveService(
-          q.useClause.map(_.value.identifier),
+          q.useClause.value.map(_.identifier.value),
           runners,
         )
         .leftMap(rf =>
           CompilationFailed.one(
             CompilationError.error(
               CompilationErrorDetails.fromResolutionFailure(rf),
-              q.useClause.fold(q.operationName.range)(_.range),
+              q.useClause.value.fold(q.operationName.range)(_.identifier.range),
             )
           )
         )

--- a/core/src/main/scala/playground/smithyql/AST.scala
+++ b/core/src/main/scala/playground/smithyql/AST.scala
@@ -11,6 +11,7 @@ import cats.kernel.Eq
 import cats.Id
 import playground.ServiceNameExtractor
 import smithy4s.Service
+import cats.kernel.Order
 
 sealed trait AST[F[_]] extends Product with Serializable {
   def mapK[G[_]: Functor](fk: F ~> G): AST[G]
@@ -62,7 +63,10 @@ object QualifiedIdentifier {
   ): QualifiedIdentifier = ServiceNameExtractor.fromService(service)
 
   implicit val show: Show[QualifiedIdentifier] = Show.fromToString
-  implicit val eq: Eq[QualifiedIdentifier] = Eq.fromUniversalEquals
+
+  implicit val ord: Order[QualifiedIdentifier] = Order.by { case QualifiedIdentifier(segs, sel) =>
+    (segs, sel)
+  }
 
 }
 

--- a/core/src/main/scala/playground/smithyql/AST.scala
+++ b/core/src/main/scala/playground/smithyql/AST.scala
@@ -58,6 +58,12 @@ final case class QualifiedIdentifier(segments: NonEmptyList[String], selection: 
 
 object QualifiedIdentifier {
 
+  def of(first: String, second: String, rest: String*): QualifiedIdentifier = {
+    val all = first :: second :: rest.toList
+
+    apply(NonEmptyList.fromListUnsafe(all.dropRight(1)), all.last)
+  }
+
   def fromShapeId(shapeId: ShapeId): QualifiedIdentifier = QualifiedIdentifier(
     shapeId.namespace.split("\\.").toList.toNel.getOrElse(sys.error("impossible! " + shapeId)),
     shapeId.name,

--- a/core/src/main/scala/playground/smithyql/CompletionVisitor.scala
+++ b/core/src/main/scala/playground/smithyql/CompletionVisitor.scala
@@ -37,6 +37,7 @@ import NodeContext.PathEntry
 import NodeContext.^^:
 import NodeContext.Root
 import cats.Id
+import playground.ServiceNameExtractor
 
 trait CompletionResolver[+A] {
   def getCompletions(ctx: NodeContext): List[CompletionItem]
@@ -180,7 +181,7 @@ object CompletionItem {
   }
 
   def describeService(service: DynamicSchemaIndex.ServiceWrapper): String =
-    s": service ${service.service.id.name}"
+    s": service ${ServiceNameExtractor.fromService(service.service).selection}"
 
   def describeSchema(schema: Schema[_]): () => String =
     schema match {

--- a/core/src/main/scala/playground/smithyql/DSL.scala
+++ b/core/src/main/scala/playground/smithyql/DSL.scala
@@ -22,7 +22,7 @@ object DSL {
 
     def useService(path0: String, pathRest: String*)(service: String): Query[Id] = q.copy[Id](
       useClause = Some(
-        UseClause(QualifiedIdentifier(NonEmptyList(path0, pathRest.toList), service))
+        UseClause[Id](QualifiedIdentifier(NonEmptyList(path0, pathRest.toList), service))
       )
     )
 

--- a/core/src/main/scala/playground/smithyql/Formatter.scala
+++ b/core/src/main/scala/playground/smithyql/Formatter.scala
@@ -20,11 +20,13 @@ object Formatter {
     }
 
   def renderUseClause(
-    clause: UseClause
-  ): Doc = Doc
-    .text("use")
-    .space("service")
-    .space(renderIdent(clause.identifier))
+    clause: UseClause[WithSource]
+  ): Doc =
+    // comments in clause are not allowed so we can ignore them when printing
+    Doc
+      .text("use")
+      .space("service")
+      .space(renderIdent(clause.identifier.value))
 
   def renderIdent(ident: QualifiedIdentifier): Doc =
     Doc.intercalate(
@@ -151,14 +153,10 @@ object Formatter {
   }
 
   def writeQuery(q: Query[WithSource]): Doc =
-    // note: commenting a clause seems to make it disappear on formatting
-    q.useClause
-      .fold(Doc.empty)(a =>
-        comments(a.commentsLeft) +
-          renderUseClause(a.value) +
-          Doc.hardLine +
-          comments(a.commentsRight) + Doc.hardLine
-      ) +
+    (comments(q.useClause.commentsLeft) +
+      q.useClause.value.fold(Doc.empty)(renderUseClause) +
+      Doc.hardLine +
+      comments(q.useClause.commentsRight) + Doc.hardLine) +
       comments(q.operationName.commentsLeft) +
       Doc.text(q.operationName.value.text) +
       Doc.space +

--- a/core/src/main/scala/playground/smithyql/Formatter.scala
+++ b/core/src/main/scala/playground/smithyql/Formatter.scala
@@ -10,7 +10,15 @@ object Formatter {
     w: Int,
   ): String = writeQuery(q).renderTrim(w)
 
-  def writeAst(ast: InputNode[WithSource]): Doc =
+  def writeAst(ast: AST[WithSource]): Doc =
+    ast match {
+      case o: OperationName[WithSource] => renderOperationName(o)
+      case q: Query[WithSource]         => writeQuery(q)
+      case u: UseClause[WithSource]     => renderUseClause(u)
+      case n: InputNode[WithSource]     => writeInputNode(n)
+    }
+
+  def writeInputNode(ast: InputNode[WithSource]): Doc =
     ast match {
       case s @ Struct(_)     => renderStruct(s)
       case IntLiteral(i)     => Doc.text(i.toString())
@@ -18,6 +26,8 @@ object Formatter {
       case StringLiteral(s)  => Doc.text(renderStringLiteral(s))
       case l @ Listed(_)     => renderSequence(l)
     }
+
+  def renderOperationName(o: OperationName[WithSource]): Doc = Doc.text(o.text)
 
   def renderUseClause(
     clause: UseClause[WithSource]
@@ -66,7 +76,7 @@ object Formatter {
             else
               Doc.lineOrSpace
 
-          sepBefore + writeAst(v.value)
+          sepBefore + writeInputNode(v.value)
         } + {
           if (v.commentsRight.isEmpty)
             Doc.empty
@@ -153,27 +163,40 @@ object Formatter {
     }
   }
 
-  def writeQuery(q: Query[WithSource]): Doc =
-    (comments(q.useClause.commentsLeft) +
-      q.useClause.value.fold(Doc.empty)(renderUseClause) +
-      Doc.hardLine +
-      comments(q.useClause.commentsRight) + Doc.hardLine) +
+  def writeQuery(q: Query[WithSource]): Doc = {
+
+    val useClausePart =
+      comments(q.useClause.commentsLeft) +
+        q.useClause.value.fold(Doc.empty)(renderUseClause(_) + Doc.hardLine) +
+        comments(q.useClause.commentsRight) + (if (q.useClause.value.isEmpty)
+                                                 Doc.empty
+                                               else
+                                                 Doc.hardLine)
+
+    val opNamePart =
       comments(q.operationName.commentsLeft) +
-      Doc.text(q.operationName.value.text) +
-      Doc.space +
-      comments(q.operationName.commentsRight) +
+        writeAst(q.operationName.value) +
+        Doc.space +
+        comments(q.operationName.commentsRight)
+
+    val inputPart =
       comments(q.input.commentsLeft) +
-      writeAst(q.input.value) + {
-        if (q.input.commentsRight.isEmpty)
-          Doc.empty
-        else
-          Doc.hardLine
-      } +
-      comments(q.input.commentsRight) + {
-        if (q.input.commentsRight.isEmpty)
-          Doc.hardLine
-        else
-          Doc.empty
-      }
+        writeInputNode(q.input.value) + {
+          if (q.input.commentsRight.isEmpty)
+            Doc.empty
+          else
+            Doc.hardLine
+        } +
+        comments(q.input.commentsRight) + {
+          if (q.input.commentsRight.isEmpty)
+            Doc.hardLine
+          else
+            Doc.empty
+        }
+
+    useClausePart +
+      opNamePart +
+      inputPart
+  }
 
 }

--- a/core/src/main/scala/playground/smithyql/NodeContext.scala
+++ b/core/src/main/scala/playground/smithyql/NodeContext.scala
@@ -14,6 +14,7 @@ sealed trait NodeContext extends Product with Serializable with NodeContext.Path
 
         context
           .map {
+            case AtUseClause        => ".useClause"
             case AtOperationName    => ".operationName"
             case AtOperationInput   => ".input"
             case CollectionEntry(i) => s".[${i.getOrElse("")}]"
@@ -66,6 +67,7 @@ object NodeContext {
   sealed trait PathEntry extends Product with Serializable
 
   object PathEntry {
+    case object AtUseClause extends PathEntry
     case object AtOperationName extends PathEntry
     case object AtOperationInput extends PathEntry
     final case class StructValue(key: String) extends PathEntry
@@ -77,16 +79,17 @@ object NodeContext {
     trait TraversalOps {
       self: NodeContext =>
 
-      def inOperationName: NodeContext = append(NodeContext.PathEntry.AtOperationName)
-      def inOperationInput: NodeContext = append(NodeContext.PathEntry.AtOperationInput)
-      def inStructValue(key: String): NodeContext = append(NodeContext.PathEntry.StructValue(key))
+      def inUseClause: NodeContext = append(PathEntry.AtUseClause)
+      def inOperationName: NodeContext = append(PathEntry.AtOperationName)
+      def inOperationInput: NodeContext = append(PathEntry.AtOperationInput)
+      def inStructValue(key: String): NodeContext = append(PathEntry.StructValue(key))
 
       def inCollectionEntry(index: Option[Int]): NodeContext = append(
-        NodeContext.PathEntry.CollectionEntry(index)
+        PathEntry.CollectionEntry(index)
       )
 
-      def inStructBody: NodeContext = append(NodeContext.PathEntry.StructBody)
-      def inQuotes: NodeContext = append(NodeContext.PathEntry.Quotes)
+      def inStructBody: NodeContext = append(PathEntry.StructBody)
+      def inQuotes: NodeContext = append(PathEntry.Quotes)
 
     }
 

--- a/core/src/main/scala/playground/smithyql/Parser.scala
+++ b/core/src/main/scala/playground/smithyql/Parser.scala
@@ -135,7 +135,7 @@ object SmithyQLParser {
     val qualifiedIdent: Parser[QualifiedIdentifier] =
       (
         rawIdent.repSep(tokens.dot.surroundedBy(tokens.whitespace)),
-        tokens.hash *> rawIdent.surroundedBy(tokens.whitespace),
+        tokens.hash *> rawIdent,
       ).mapN(QualifiedIdentifier.apply)
 
     val useClause: Parser[UseClause[T]] = {

--- a/core/src/main/scala/playground/smithyql/Parser.scala
+++ b/core/src/main/scala/playground/smithyql/Parser.scala
@@ -75,6 +75,20 @@ object SmithyQLParser {
         )
     }
 
+    def withRange[A](
+      p: Parser[A]
+    ): Parser[T[A]] = (Parser.index.with1 ~ p ~ Parser.index).map {
+      case ((indexBefore, v), indexAfter) =>
+        val range = SourceRange(Position(indexBefore), Position(indexAfter))
+
+        WithSource(
+          commentsLeft = Nil,
+          commentsRight = Nil,
+          range = range,
+          value = v,
+        )
+    }
+
     private[SmithyQLParser] val rawIdentifier =
       (Rfc5234.alpha ~ Parser.charsWhile0(_.isLetterOrDigit))
         .map { case (ch, s) => s.prepended(ch) }
@@ -124,12 +138,12 @@ object SmithyQLParser {
         tokens.hash *> rawIdent.surroundedBy(tokens.whitespace),
       ).mapN(QualifiedIdentifier.apply)
 
-    val useClause: Parser[UseClause] = {
+    val useClause: Parser[UseClause[T]] = {
       string("use") *>
         string("service")
           .surroundedBy(tokens.whitespace) *>
-        qualifiedIdent
-    }.map(UseClause.apply)
+        tokens.withRange(qualifiedIdent)
+    }.map(UseClause.apply[T])
 
     val intLiteral = tokens
       .number
@@ -228,17 +242,15 @@ object SmithyQLParser {
         }
     }
 
-    val useClauseWithSource: Parser0[Option[WithSource[UseClause]]] =
-      (tokens.comments ~
-        Parser.index ~ useClause ~ Parser.index).backtrack.?.map {
-        _.map { case (((commentsBefore, indexBefore), useClause), indexAfter) =>
+    val useClauseWithSource: Parser0[WithSource[Option[UseClause[WithSource]]]] =
+      (tokens.comments ~ Parser.index ~ useClause.? ~ Parser.index).map {
+        case (((commentsBefore, indexBefore), useClause), indexAfter) =>
           WithSource(
             commentsBefore,
             Nil,
             SourceRange(Position(indexBefore), Position(indexAfter)),
             useClause,
           )
-        }
       }
 
     (useClauseWithSource.with1 ~

--- a/core/src/main/scala/playground/smithyql/RangeIndex.scala
+++ b/core/src/main/scala/playground/smithyql/RangeIndex.scala
@@ -12,10 +12,9 @@ object RangeIndex {
     new RangeIndex {
 
       private val allRanges: List[ContextRange] =
-        findInOperationName(q.operationName) ++ findInNode(
-          q.input,
-          NodeContext.Root.inOperationInput,
-        )
+        findInUseClause(q.useClause) ++
+          findInOperationName(q.operationName) ++
+          findInNode(q.input, NodeContext.Root.inOperationInput)
 
       // Console
       //   .err
@@ -31,6 +30,16 @@ object RangeIndex {
       ): Option[ContextRange] = allRanges.filter(_.range.contains(pos)).maxByOption(_.ctx.length)
 
     }
+
+  private def findInUseClause(
+    useClauseOpt: WithSource[Option[UseClause[WithSource]]]
+  ): List[ContextRange] =
+    useClauseOpt
+      .value
+      .map { useClause =>
+        ContextRange(useClause.identifier.range, NodeContext.Root.inUseClause)
+      }
+      .toList
 
   private def findInOperationName(
     operationName: WithSource[OperationName]

--- a/core/src/main/scala/playground/smithyql/WithSource.scala
+++ b/core/src/main/scala/playground/smithyql/WithSource.scala
@@ -95,7 +95,12 @@ object WithSource {
       listed = _.values.allComments(_.flatMap(_.allComments(comments))),
     )
 
-    q.useClause.foldMap(u => u.commentsLeft ++ u.commentsRight) ++
+    q.useClause.commentsLeft ++ q
+      .useClause
+      .value
+      .foldMap(u => u.identifier.commentsLeft ++ u.identifier.commentsRight) ++ q
+      .useClause
+      .commentsRight ++
       q.operationName.allComments(_ => Nil) ++
       q.input
         .allComments(

--- a/core/src/main/smithy/std.smithy
+++ b/core/src/main/smithy/std.smithy
@@ -6,10 +6,12 @@ use smithy4s.api#UUID
 structure stdlib {}
 
 @stdlib
+@documentation("A standard library service providing random generators of data.")
 service Random {
   operations: [NextUUID]
 }
 
+@documentation("Generates a new UUID.")
 operation NextUUID {
   output: NextUUIDOutput
 }
@@ -20,10 +22,12 @@ structure NextUUIDOutput {
 }
 
 @stdlib
+@documentation("A standard library service providing time operations.")
 service Clock {
   operations: [CurrentTimestamp]
 }
 
+@documentation("Provides the current time as a Timestamp.")
 operation CurrentTimestamp {
   output: CurrentTimestampOutput
 }

--- a/core/src/test/scala/playground/Assertions.scala
+++ b/core/src/test/scala/playground/Assertions.scala
@@ -5,6 +5,7 @@ import com.softwaremill.diffx.Diff
 import weaver.Expectations
 import weaver.Log
 import weaver.SourceLocation
+import com.softwaremill.diffx.ShowConfig
 
 object Assertions extends Expectations.Helpers {
 
@@ -17,7 +18,7 @@ object Assertions extends Expectations.Helpers {
   ): IO[Expectations] =
     Diff[A].apply(expected, actual) match {
       case d if d.isIdentical => IO.pure(success)
-      case d                  => log.info(d.show()).as(failure("Diff failed"))
+      case d                  => log.info(d.show()(ShowConfig.dark)).as(failure("Diff failed"))
     }
 
 }

--- a/core/src/test/scala/playground/DocumentSymbolProviderTests.scala
+++ b/core/src/test/scala/playground/DocumentSymbolProviderTests.scala
@@ -39,6 +39,30 @@ object DocumentSymbolProviderTests extends SimpleIOSuite {
 
   }
 
+  test("hello world with use clause") { (_, log) =>
+    implicit val l = log
+    val dsl = makeDSL("""use service pkg#World
+                        |hello { }""".stripMargin)
+
+    val expected = List(
+      dsl.symbol(
+        "pkg#World",
+        SymbolKind.Package,
+        "pkg#World",
+        "pkg#World",
+        Nil,
+      ),
+      dsl.symbol(
+        "hello",
+        SymbolKind.Function,
+        "hello",
+        "hello { ",
+      ),
+    )
+
+    assertNoDiff(dsl.symbols, expected)
+  }
+
   test("hello world with one field") { (_, log) =>
     implicit val l = log
     val dsl = makeDSL("""hello { greeting = 42 }""")

--- a/core/src/test/scala/playground/smithyql/Arbitraries.scala
+++ b/core/src/test/scala/playground/smithyql/Arbitraries.scala
@@ -54,7 +54,9 @@ object Arbitraries {
     Gen.resultOf(QualifiedIdentifier.apply)
   )
 
-  implicit val arbitraryUseClause: Arbitrary[UseClause] = Arbitrary(Gen.resultOf(UseClause.apply))
+  implicit val arbitraryUseClause: Arbitrary[UseClause[WithSource]] = Arbitrary(
+    Gen.resultOf(UseClause.apply[WithSource])
+  )
 
   implicit val arbBool: Arbitrary[BooleanLiteral[WithSource]] = Arbitrary {
     Gen.resultOf(BooleanLiteral[WithSource])

--- a/core/src/test/scala/playground/smithyql/CompletionProviderTests.scala
+++ b/core/src/test/scala/playground/smithyql/CompletionProviderTests.scala
@@ -1,0 +1,151 @@
+package playground.smithyql
+
+import cats.Id
+import cats.data.NonEmptyList
+import com.softwaremill.diffx.generic.auto._
+import demo.smithy.DemoServiceGen
+import playground.Assertions._
+import playground.CompletionProvider
+import playground.std.RandomGen
+import smithy4s.Service
+import smithy4s.dynamic.DynamicSchemaIndex
+import weaver._
+import cats.implicits._
+import playground.std.ClockGen
+
+object CompletionProviderTests extends SimpleIOSuite {
+
+  private def wrap[Algg[_[_, _, _, _, _]], Opp[_, _, _, _, _]](
+    svc: Service[Algg, Opp]
+  ): DynamicSchemaIndex.ServiceWrapper =
+    new DynamicSchemaIndex.ServiceWrapper {
+      type Alg[Oppp[_, _, _, _, _]] = Algg[Oppp]
+
+      type Op[I, E, O, SE, SO] = Opp[I, E, O, SE, SO]
+      val service: Service[Alg, Op] = svc
+    }
+
+  private val demoServiceId = QualifiedIdentifier.of("demo", "smithy", "DemoService")
+
+  pureTest("completing existing use clause") {
+    val service = wrap(DemoServiceGen)
+
+    val provider = CompletionProvider.forServices(List(service))
+
+    val result = provider.provide(
+      """use service a#B
+        |hello {}""".stripMargin,
+      Position("use service ".length),
+    )
+
+    val expected = List(
+      CompletionItem.useServiceClause(
+        demoServiceId,
+        service,
+      )
+    )
+
+    assert(result == expected)
+  }
+
+  test("completing empty file") { (_, log) =>
+    implicit val l = log
+
+    val service = wrap(DemoServiceGen)
+    val random = wrap(RandomGen)
+
+    val provider = CompletionProvider.forServices(List(service, random))
+
+    val result = provider.provide(
+      "",
+      Position(0),
+    )
+
+    val expected =
+      DemoServiceGen
+        .endpoints
+        .map(endpoint =>
+          CompletionItem.forOperation(
+            insertUseClause = CompletionItem
+              .InsertUseClause
+              .Required(
+                List(
+                  OperationName[Id]("CreateHero"),
+                  OperationName[Id]("CreateSubscription"),
+                  OperationName[Id]("GetPowers"),
+                ).tupleRight(NonEmptyList.one(demoServiceId)).toMap
+              ),
+            endpoint,
+            demoServiceId,
+          )
+        ) ++ RandomGen
+        .endpoints
+        .map(endpoint =>
+          CompletionItem.forOperation(
+            insertUseClause = CompletionItem
+              .InsertUseClause
+              .Required(
+                Map(
+                  OperationName[Id]("NextUUID") -> NonEmptyList
+                    .one(QualifiedIdentifier.forService(RandomGen))
+                )
+              ),
+            endpoint,
+            QualifiedIdentifier.forService(RandomGen),
+          )
+        )
+
+    assertNoDiff(result, expected)
+  }
+
+  pureTest("completing empty file - one service exists") {
+    val random = wrap(RandomGen)
+    val provider = CompletionProvider.forServices(List(random))
+
+    val result = provider.provide(
+      "",
+      Position(0),
+    )
+
+    val expected = RandomGen
+      .endpoints
+      .map(endpoint =>
+        CompletionItem.forOperation(
+          insertUseClause =
+            CompletionItem
+              .InsertUseClause
+              .NotRequired,
+          endpoint,
+          QualifiedIdentifier.forService(RandomGen),
+        )
+      )
+
+    assert(result == expected)
+  }
+
+  test("completing operation - use clause exists, multiple services available") { (_, log) =>
+    implicit val l = log
+    val clock = wrap(ClockGen)
+    val random = wrap(RandomGen)
+    val provider = CompletionProvider.forServices(List(clock, random))
+
+    val result = provider.provide(
+      """use service playground.std#Clock
+        |hello {}""".stripMargin,
+      Position("use service playground.std#Clock\n".length),
+    )
+
+    val expected = ClockGen
+      .service
+      .endpoints
+      .map(endpoint =>
+        CompletionItem.forOperation(
+          insertUseClause = CompletionItem.InsertUseClause.NotRequired,
+          endpoint,
+          QualifiedIdentifier.forService(ClockGen),
+        )
+      )
+
+    assertNoDiff(result, expected)
+  }
+}

--- a/core/src/test/scala/playground/smithyql/FormattingTests.scala
+++ b/core/src/test/scala/playground/smithyql/FormattingTests.scala
@@ -29,9 +29,7 @@ object FormattingTests extends SimpleIOSuite with Checkers {
         "values" -> List("hello", "world")
       )
       .mapK(WithSource.liftId)
-  }("""
-      |
-      |hello {
+  }("""hello {
       |  values = [
       |       "hello",
       |       "world",
@@ -45,9 +43,7 @@ object FormattingTests extends SimpleIOSuite with Checkers {
         "values" -> List(42, 10)
       )
       .mapK(WithSource.liftId)
-  }("""
-      |
-      |hello {
+  }("""hello {
       |  values = [
       |       42,
       |       10,
@@ -68,9 +64,7 @@ object FormattingTests extends SimpleIOSuite with Checkers {
       ] // and can have comments after themselves
       ,
     }""")
-  }("""
-      |
-      |hello {
+  }("""hello {
       |  input = // this is a list
       |    [
       |       // list elems can be anything
@@ -108,11 +102,8 @@ object FormattingTests extends SimpleIOSuite with Checkers {
     parse("""//before call
     hello { }""")
   }("""// before call
-      |
-      |
       |hello {
       |
       |}
       |""".stripMargin)
-
 }

--- a/core/src/test/scala/playground/smithyql/FormattingTests.scala
+++ b/core/src/test/scala/playground/smithyql/FormattingTests.scala
@@ -1,6 +1,5 @@
 package playground.smithyql
 
-import cats.implicits._
 import weaver._
 import weaver.scalacheck.Checkers
 
@@ -30,7 +29,9 @@ object FormattingTests extends SimpleIOSuite with Checkers {
         "values" -> List("hello", "world")
       )
       .mapK(WithSource.liftId)
-  }("""hello {
+  }("""
+      |
+      |hello {
       |  values = [
       |       "hello",
       |       "world",
@@ -44,7 +45,9 @@ object FormattingTests extends SimpleIOSuite with Checkers {
         "values" -> List(42, 10)
       )
       .mapK(WithSource.liftId)
-  }("""hello {
+  }("""
+      |
+      |hello {
       |  values = [
       |       42,
       |       10,
@@ -65,7 +68,9 @@ object FormattingTests extends SimpleIOSuite with Checkers {
       ] // and can have comments after themselves
       ,
     }""")
-  }("""hello {
+  }("""
+      |
+      |hello {
       |  input = // this is a list
       |    [
       |       // list elems can be anything
@@ -103,6 +108,8 @@ object FormattingTests extends SimpleIOSuite with Checkers {
     parse("""//before call
     hello { }""")
   }("""// before call
+      |
+      |
       |hello {
       |
       |}

--- a/lsp/src/main/scala/playground/lsp/converters.scala
+++ b/lsp/src/main/scala/playground/lsp/converters.scala
@@ -52,6 +52,7 @@ object converters {
         case CompletionItemKind.Constant    => lsp4j.CompletionItemKind.Constant
         case CompletionItemKind.UnionMember => lsp4j.CompletionItemKind.Class
         case CompletionItemKind.Function    => lsp4j.CompletionItemKind.Function
+        case CompletionItemKind.Module      => lsp4j.CompletionItemKind.Module
       }
 
       val insertText =

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10,6 +10,8 @@ export function activate(context: ExtensionContext) {
     .getConfiguration()
     .get<string>("smithyql.server.version");
 
+  const coursierTTL = serverVersion === "latest.integration" ? "0" : "1h";
+
   const outputChannel = window.createOutputChannel(
     "Smithy Playground",
     "smithyql"
@@ -24,7 +26,7 @@ export function activate(context: ExtensionContext) {
         "launch",
         `${serverArtifact}:${serverVersion}`,
         "--ttl",
-        "1h",
+        coursierTTL,
         // "--",
         // "-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=5005",
       ],


### PR DESCRIPTION
- Fixing the document symbol provider: whitespace after a `use`-d service's identifier is no longer included in the range
- Service completions can be triggered on an existing use clause
- (technical) the identifier now has a separate range from the entire use clause
- services are sorted by ID in ambiguity errors