### PR TITLE
Add dynamic surjection support

### DIFF
--- a/core/src/main/scala/playground/QueryCompiler.scala
+++ b/core/src/main/scala/playground/QueryCompiler.scala
@@ -41,15 +41,28 @@ import smithy4s.schema.Primitive.PTimestamp
 import smithy4s.schema.Primitive.PUUID
 import smithy4s.schema.Primitive.PUnit
 import smithy4s.schema.Schema
+import smithy4s.schema.Schema.BijectionSchema
+import smithy4s.schema.Schema.CollectionSchema
+import smithy4s.schema.Schema.EnumerationSchema
+import smithy4s.schema.Schema.LazySchema
+import smithy4s.schema.Schema.SurjectionSchema
+import smithy4s.schema.Schema.MapSchema
+import smithy4s.schema.Schema.PrimitiveSchema
+import smithy4s.schema.Schema.StructSchema
+import smithy4s.schema.Schema.UnionSchema
 import smithy4s.schema.SchemaField
 import smithy4s.schema.SchemaVisitor
+import smithy4s.~>
 
 import java.util.UUID
+
 import types._
 import util.chaining._
 import PartialCompiler.WAST
 import smithy4s.ByteArray
 import java.util.Base64
+import smithy4s.Validator
+import smithy4s.ShapeTag
 
 trait PartialCompiler[A] {
   final def emap[B](f: A => PartialCompiler.Result[B]): PartialCompiler[B] =
@@ -284,7 +297,90 @@ object CompilationErrorDetails {
   final case class EnumFallback(enumName: String) extends CompilationErrorDetails
 }
 
-object QueryCompiler extends SchemaVisitor[PartialCompiler] {
+object QueryCompiler {
+  val full = new TransitiveCompiler(AddDynamicRefinements) andThen QueryCompilerInternal
+
+}
+
+// Applies the underlying transformation on each node of the schema that has its own hints
+class TransitiveCompiler(underlying: Schema ~> Schema) extends (Schema ~> Schema) {
+
+  def apply[A](fa: Schema[A]): Schema[A] =
+    fa match {
+      case e @ EnumerationSchema(_, _, _, _) => underlying(e)
+      case p @ PrimitiveSchema(_, _, _)      => underlying(p)
+      case u @ UnionSchema(_, _, _, _) =>
+        underlying(u.copy(alternatives = u.alternatives.map(_.mapK(this))))
+      case BijectionSchema(s, to, from) => BijectionSchema(this(s), to, from)
+      case LazySchema(suspend)          => LazySchema(suspend.map(this.apply))
+      case SurjectionSchema(underlying, refinement, from) =>
+        SurjectionSchema(this(underlying), refinement, from)
+      case c @ CollectionSchema(_, _, _, _) => c.copy(member = this(c.member))
+      case m @ MapSchema(_, _, _, _) => underlying(m.copy(key = this(m.key), value = this(m.value)))
+      case s @ StructSchema(_, _, _, _) => underlying(s.copy(fields = s.fields.map(_.mapK(this))))
+    }
+
+}
+
+object AddDynamicRefinements extends (Schema ~> Schema) {
+
+  // todo: https://github.com/disneystreaming/smithy4s/pull/348
+  private def void[C, A](
+    underlying: Validator[C, A, _]
+  ): Validator.Simple[C, A] =
+    new Validator.Simple[C, A] {
+
+      def make(c: C): Refinement[A, A] { type Constraint = C } =
+        new Refinement[A, A] {
+
+          private val wrapped = underlying.make(c)
+
+          type Constraint = C
+
+          val tag: ShapeTag[C] = underlying.tag
+
+          val constraint: C = c
+
+          def apply(a: A): Either[String, A] = wrapped(a).as(a)
+
+          def unchecked(a: A): A = a
+        }
+
+      def tag: ShapeTag[C] = underlying.tag
+
+    }
+
+  private implicit class SchemaOps[A](schema: Schema[A]) {
+    def reifyHint[B](implicit rp: Validator[B, A, _]): Schema[A] = schema.validated(void(rp))
+  }
+
+  private def collection[C[_], A](
+    schema: Schema.CollectionSchema[C, A]
+  ): Schema[C[A]] =
+    schema.tag match {
+      case ListTag       => schema.reifyHint(Validator.iterableLengthConstraint[List, A])
+      case VectorTag     => schema.reifyHint(Validator.iterableLengthConstraint[Vector, A])
+      case SetTag        => schema.reifyHint(Validator.iterableLengthConstraint[Set, A])
+      case IndexedSeqTag => schema.reifyHint(Validator.iterableLengthConstraint[IndexedSeq, A])
+    }
+
+  def apply[A](schema: Schema[A]): Schema[A] =
+    schema match {
+      case PrimitiveSchema(_, _, tag) =>
+        tag match {
+          case PString => schema.reifyHint[api.Length].reifyHint[api.Pattern]
+          case PInt    => schema.reifyHint[api.Range]
+          case _       => schema
+        }
+
+      case c: CollectionSchema[_, _] => collection(c)
+      case m: MapSchema[_, _]        => m.reifyHint[api.Length]
+      case _                         => schema
+    }
+
+}
+
+object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
 
   private def checkRange[A, B](
     pc: PartialCompiler[A]
@@ -569,7 +665,7 @@ object QueryCompiler extends SchemaVisitor[PartialCompiler] {
           CompilationError
             .error(
               StructMismatch(
-                s.value.fields.value.keys.map(_.value.text).toList,
+                s.value.fields.value.keys.map(_.value.text),
                 labels,
               ),
               s.range,
@@ -585,18 +681,21 @@ object QueryCompiler extends SchemaVisitor[PartialCompiler] {
     from: B => A,
   ): PartialCompiler[B] = schema.compile(this).map(to)
 
-  def surject[A, B](schema: Schema[A], to: Refinement[A, B], from: B => A): PartialCompiler[B] =
-    (schema.compile(this), PartialCompiler.pos).tupled.emap { case (a, pos) =>
-      to(a)
-        .toIor
-        .leftMap { msg =>
-          CompilationError.error(
-            CompilationErrorDetails.RefinementFailure(msg),
-            pos,
-          )
-        }
-        .toIorNec
-    }
+  def surject[A, B](
+    pc: Schema[A],
+    refinement: Refinement[A, B],
+    from: B => A,
+  ): PartialCompiler[B] = (pc.compile(this), PartialCompiler.pos).tupled.emap { case (a, pos) =>
+    refinement(a)
+      .toIor
+      .leftMap { msg =>
+        CompilationError.error(
+          CompilationErrorDetails.RefinementFailure(msg),
+          pos,
+        )
+      }
+      .toIorNec
+  }
 
   def lazily[A](suspend: Lazy[Schema[A]]): PartialCompiler[A] = {
     val it = suspend.map(_.compile(this))

--- a/core/src/main/scala/playground/QueryCompiler.scala
+++ b/core/src/main/scala/playground/QueryCompiler.scala
@@ -368,9 +368,17 @@ object AddDynamicRefinements extends (Schema ~> Schema) {
     schema match {
       case PrimitiveSchema(_, _, tag) =>
         tag match {
-          case PString => schema.reifyHint[api.Length].reifyHint[api.Pattern]
-          case PInt    => schema.reifyHint[api.Range]
-          case _       => schema
+          case PString     => schema.reifyHint[api.Length].reifyHint[api.Pattern]
+          case PByte       => schema.reifyHint[api.Range]
+          case PShort      => schema.reifyHint[api.Range]
+          case PInt        => schema.reifyHint[api.Range]
+          case PLong       => schema.reifyHint[api.Range]
+          case PFloat      => schema.reifyHint[api.Range]
+          case PDouble     => schema.reifyHint[api.Range]
+          case PBigInt     => schema.reifyHint[api.Range]
+          case PBigDecimal => schema.reifyHint[api.Range]
+          case PBlob       => schema.reifyHint[api.Length]
+          case PUnit | PTimestamp | PDocument | PBoolean | PUUID => schema
         }
 
       case c: CollectionSchema[_, _] => collection(c)

--- a/core/src/main/scala/playground/run.scala
+++ b/core/src/main/scala/playground/run.scala
@@ -113,7 +113,7 @@ private class ServiceCompiler[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]](
   private def compileEndpoint[In, Err, Out](
     e: Endpoint[Op, In, Err, Out, _, _]
   ): WithSource[InputNode[WithSource]] => IorNel[CompilationError, CompiledInput] = {
-    val inputCompiler = e.input.compile(QueryCompiler)
+    val inputCompiler = e.input.compile(QueryCompiler.full)
     val outputEncoder = NodeEncoder.derive(e.output)
     val errorEncoder = e.errorable.map(e => NodeEncoder.derive(e.error))
 

--- a/core/src/test/smithy/demo.smithy
+++ b/core/src/test/smithy/demo.smithy
@@ -199,12 +199,16 @@ structure HasNewtypes {
   str: MyString,
   power: Power,
   powerMap: PowerMap,
-  anUUID: smithy4s.api#UUID
+  anUUID: smithy4s.api#UUID,
 }
+
 
 integer MyInt
 
 string MyString
+
+@length(min: 1)
+string StringWithLength
 
 structure HasDeprecations {
   @deprecated(message: "Made-up reason")


### PR DESCRIPTION
Backported from #62.

This enables all validations currently supported by Smithy4s - they'll be used while checking queries for correctness.

Support for custom validations / refinements (coming in the next major Smithy4s release) will most likely be provided in the future using plugin infrastructure.

Here's what it looks like for a string with `@length(min: 1)`:

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/894884/184892630-a99fe353-d2ac-4ccc-9275-7f9752ac711c.png">
