### PR TITLE
Split / rename compiler classes

### DIFF
--- a/core/src/main/scala/playground/CompilationError.scala
+++ b/core/src/main/scala/playground/CompilationError.scala
@@ -1,0 +1,220 @@
+package playground
+
+import cats.Id
+import cats.data.NonEmptyList
+import cats.implicits._
+import playground.CompilationErrorDetails._
+import playground.smithyql._
+import smithy.api
+import smithy.api.TimestampFormat
+
+final case class CompilationError(
+  err: CompilationErrorDetails,
+  range: SourceRange,
+  severity: DiagnosticSeverity,
+  tags: Set[DiagnosticTag],
+  relatedInfo: List[DiagnosticRelatedInformation],
+) {
+  def deprecated: CompilationError = copy(tags = tags + DiagnosticTag.Deprecated)
+
+  def isError: Boolean = severity == DiagnosticSeverity.Error
+  def isWarning: Boolean = severity == DiagnosticSeverity.Warning
+}
+
+object CompilationError {
+
+  def error(
+    err: CompilationErrorDetails,
+    range: SourceRange,
+  ): CompilationError = default(err, range, DiagnosticSeverity.Error)
+
+  def warning(
+    err: CompilationErrorDetails,
+    range: SourceRange,
+  ): CompilationError = default(err, range, DiagnosticSeverity.Warning)
+
+  def deprecation(
+    info: api.Deprecated,
+    range: SourceRange,
+  ): CompilationError =
+    CompilationError
+      .warning(CompilationErrorDetails.DeprecatedItem(info), range)
+      .deprecated
+
+  def default(
+    err: CompilationErrorDetails,
+    range: SourceRange,
+    severity: DiagnosticSeverity,
+  ): CompilationError = CompilationError(
+    err = err,
+    range = range,
+    severity = severity,
+    tags = Set.empty,
+    relatedInfo = Nil,
+  )
+
+}
+
+sealed trait DiagnosticSeverity extends Product with Serializable
+
+object DiagnosticSeverity {
+  case object Warning extends DiagnosticSeverity
+  case object Error extends DiagnosticSeverity
+  case object Information extends DiagnosticSeverity
+}
+
+sealed trait DiagnosticTag extends Product with Serializable
+
+object DiagnosticTag {
+  case object Deprecated extends DiagnosticTag
+  case object Unused extends DiagnosticTag
+}
+
+final case class DiagnosticRelatedInformation(
+  location: RelativeLocation,
+  message: CompilationErrorDetails,
+)
+
+final case class RelativeLocation(document: DocumentReference, range: SourceRange)
+  extends Product
+  with Serializable
+
+sealed trait DocumentReference extends Product with Serializable
+
+object DocumentReference {
+  case object SameFile extends DocumentReference
+}
+
+sealed trait CompilationErrorDetails extends Product with Serializable {
+
+  def render: String =
+    this match {
+      case Message(text)                  => text
+      case DeprecatedItem(info)           => "Deprecated" + CompletionItem.deprecationString(info)
+      case InvalidUUID                    => "Invalid UUID"
+      case InvalidBlob                    => "Invalid blob, expected base64-encoded string"
+      case ConflictingServiceReference(_) => "Conflicting service references"
+
+      case NumberOutOfRange(value, expectedType) => s"Number out of range for $expectedType: $value"
+      case EnumFallback(enumName) =>
+        s"""Matching enums by value is deprecated and may be removed in the future. Use $enumName instead.""".stripMargin
+      case DuplicateItem => "Duplicate item - some entries will be dropped to fit in a set shape."
+      case AmbiguousService(matching) =>
+        s"""Multiple services are available. Add a use clause to specify the service you want to use.
+           |Available services:""".stripMargin + matching
+          .sorted
+          .map(UseClause[Id](_).mapK(WithSource.liftId))
+          .map(Formatter.renderUseClause(_).render(Int.MaxValue))
+          .mkString_("\n", "\n", ".")
+
+      case UnknownService(id, known) =>
+        s"Unknown service: ${id.render}. Known services: ${known.map(_.render).mkString(", ")}."
+
+      case RefinementFailure(msg) => s"Refinement failed: $msg."
+
+      case TypeMismatch(expected, actual) => s"Type mismatch: expected $expected, got $actual."
+
+      case OperationNotFound(name, validOperations) =>
+        s"Operation ${name.text} not found. Available operations: ${validOperations.map(_.text).mkString_(", ")}."
+
+      case MissingField(label) => s"Missing field $label."
+
+      case InvalidTimestampFormat(expected) => s"Invalid timestamp format, expected $expected."
+
+      case MissingDiscriminator(labels) =>
+        s"wrong shape, this union requires one of: ${labels.mkString_(", ")}."
+
+      case EmptyStruct(possibleValues) =>
+        s"found empty struct, expected one of: ${possibleValues.mkString_(", ")}."
+
+      case UnknownEnumValue(name, possibleValues) =>
+        s"Unknown enum value: $name. Available values: ${possibleValues.mkString(", ")}"
+
+      case StructMismatch(keys, possibleValues) =>
+        s"struct mismatch (keys: ${keys.mkString_(", ")}), you must choose exactly one of: ${possibleValues
+            .mkString_(", ")}."
+
+      case UnexpectedField(remainingFields) =>
+        val expectedRemainingString =
+          if (remainingFields.isEmpty)
+            ""
+          else if (remainingFields.size == 1)
+            s" Expected: ${remainingFields.head}."
+          else
+            s" Expected: one of ${remainingFields.mkString(", ")}."
+
+        s"Unexpected field.$expectedRemainingString"
+    }
+
+}
+
+object CompilationErrorDetails {
+
+  val fromResolutionFailure: ResolutionFailure => CompilationErrorDetails = {
+    case ResolutionFailure.AmbiguousService(knownServices) =>
+      CompilationErrorDetails.AmbiguousService(knownServices)
+    case ResolutionFailure.UnknownService(unknownId, knownServices) =>
+      CompilationErrorDetails.UnknownService(unknownId, knownServices)
+    case ResolutionFailure.ConflictingServiceReference(refs) =>
+      CompilationErrorDetails.ConflictingServiceReference(refs)
+
+  }
+
+  // todo: remove
+  final case class Message(text: String) extends CompilationErrorDetails
+  final case class UnknownService(id: QualifiedIdentifier, knownServices: List[QualifiedIdentifier])
+    extends CompilationErrorDetails
+
+  final case class ConflictingServiceReference(refs: List[QualifiedIdentifier])
+    extends CompilationErrorDetails
+
+  final case class AmbiguousService(
+    known: List[QualifiedIdentifier]
+  ) extends CompilationErrorDetails
+
+  final case class TypeMismatch(
+    expected: NodeKind,
+    actual: NodeKind,
+  ) extends CompilationErrorDetails
+
+  final case class OperationNotFound(
+    name: OperationName[Id],
+    validOperations: List[OperationName[Id]],
+  ) extends CompilationErrorDetails
+
+  final case class MissingField(label: String) extends CompilationErrorDetails
+
+  case object InvalidUUID extends CompilationErrorDetails
+
+  final case class NumberOutOfRange(numberValue: String, typeName: String)
+    extends CompilationErrorDetails
+
+  final case class InvalidTimestampFormat(expected: TimestampFormat) extends CompilationErrorDetails
+
+  final case class MissingDiscriminator(possibleValues: NonEmptyList[String])
+    extends CompilationErrorDetails
+
+  final case class EmptyStruct(possibleValues: NonEmptyList[String]) extends CompilationErrorDetails
+
+  final case class UnknownEnumValue(value: String, possibleValues: List[String])
+    extends CompilationErrorDetails
+
+  final case class StructMismatch(
+    keys: List[String],
+    possibleValues: NonEmptyList[String],
+  ) extends CompilationErrorDetails
+
+  final case class UnexpectedField(
+    remainingFields: List[String]
+  ) extends CompilationErrorDetails
+
+  final case class RefinementFailure(msg: String) extends CompilationErrorDetails
+
+  case object DuplicateItem extends CompilationErrorDetails
+
+  case object InvalidBlob extends CompilationErrorDetails
+
+  case class DeprecatedItem(info: api.Deprecated) extends CompilationErrorDetails
+
+  final case class EnumFallback(enumName: String) extends CompilationErrorDetails
+}

--- a/core/src/main/scala/playground/QueryCompiler.scala
+++ b/core/src/main/scala/playground/QueryCompiler.scala
@@ -1,0 +1,56 @@
+package playground
+
+import cats.Apply
+import cats.data.IorNec
+import cats.data.NonEmptyChain
+import cats.implicits._
+import playground.CompilationErrorDetails._
+import playground.smithyql._
+
+import QueryCompiler.WAST
+
+trait QueryCompiler[A] {
+  final def emap[B](f: A => QueryCompiler.Result[B]): QueryCompiler[B] =
+    ast => compile(ast).flatMap(f)
+
+  def compile(ast: WAST): QueryCompiler.Result[A]
+
+}
+
+object QueryCompiler {
+  type Result[+A] = IorNec[CompilationError, A]
+
+  implicit val apply: Apply[QueryCompiler] =
+    new Apply[QueryCompiler] {
+      def map[A, B](fa: QueryCompiler[A])(f: A => B): QueryCompiler[B] = fa.compile(_).map(f)
+
+      def ap[A, B](ff: QueryCompiler[A => B])(fa: QueryCompiler[A]): QueryCompiler[B] =
+        wast => (ff.compile(wast), fa.compile(wast)).parMapN((a, b) => a(b))
+    }
+
+  type WAST = WithSource[InputNode[WithSource]]
+
+  val pos: QueryCompiler[SourceRange] = _.range.rightIor
+  val unit: QueryCompiler[Unit] = _ => ().rightIor
+
+  def typeCheck[A](
+    expected: NodeKind
+  )(
+    f: PartialFunction[InputNode[WithSource], A]
+  ): QueryCompiler[WithSource[A]] =
+    ast =>
+      ast
+        .traverse(f.lift)
+        .toRightIor(
+          NonEmptyChain(
+            CompilationError.error(
+              TypeMismatch(
+                expected,
+                ast.value.kind,
+              ),
+              ast.range,
+            )
+          )
+        )
+
+}

--- a/core/src/main/scala/playground/QueryCompilerVisitor.scala
+++ b/core/src/main/scala/playground/QueryCompilerVisitor.scala
@@ -52,37 +52,37 @@ import java.util.UUID
 
 import types._
 import util.chaining._
-import PartialCompiler.WAST
+import QueryCompiler.WAST
 
-trait PartialCompiler[A] {
-  final def emap[B](f: A => PartialCompiler.Result[B]): PartialCompiler[B] =
+trait QueryCompiler[A] {
+  final def emap[B](f: A => QueryCompiler.Result[B]): QueryCompiler[B] =
     ast => compile(ast).flatMap(f)
 
-  def compile(ast: WAST): PartialCompiler.Result[A]
+  def compile(ast: WAST): QueryCompiler.Result[A]
 
 }
 
-object PartialCompiler {
+object QueryCompiler {
   type Result[+A] = IorNec[CompilationError, A]
 
-  implicit val apply: Apply[PartialCompiler] =
-    new Apply[PartialCompiler] {
-      def map[A, B](fa: PartialCompiler[A])(f: A => B): PartialCompiler[B] = fa.compile(_).map(f)
+  implicit val apply: Apply[QueryCompiler] =
+    new Apply[QueryCompiler] {
+      def map[A, B](fa: QueryCompiler[A])(f: A => B): QueryCompiler[B] = fa.compile(_).map(f)
 
-      def ap[A, B](ff: PartialCompiler[A => B])(fa: PartialCompiler[A]): PartialCompiler[B] =
+      def ap[A, B](ff: QueryCompiler[A => B])(fa: QueryCompiler[A]): QueryCompiler[B] =
         wast => (ff.compile(wast), fa.compile(wast)).parMapN((a, b) => a(b))
     }
 
   type WAST = WithSource[InputNode[WithSource]]
 
-  val pos: PartialCompiler[SourceRange] = _.range.rightIor
-  val unit: PartialCompiler[Unit] = _ => ().rightIor
+  val pos: QueryCompiler[SourceRange] = _.range.rightIor
+  val unit: QueryCompiler[Unit] = _ => ().rightIor
 
   def typeCheck[A](
     expected: NodeKind
   )(
     f: PartialFunction[InputNode[WithSource], A]
-  ): PartialCompiler[WithSource[A]] =
+  ): QueryCompiler[WithSource[A]] =
     ast =>
       ast
         .traverse(f.lift)
@@ -100,20 +100,20 @@ object PartialCompiler {
 
 }
 
-object QueryCompiler {
-  val full = new TransitiveCompiler(AddDynamicRefinements) andThen QueryCompilerInternal
+object QueryCompilerVisitor {
+  val full = new TransitiveCompiler(AddDynamicRefinements) andThen QueryCompilerVisitorInternal
 
 }
 
-object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
+object QueryCompilerVisitorInternal extends SchemaVisitor[QueryCompiler] {
 
   private def checkRange[A, B](
-    pc: PartialCompiler[A]
+    pc: QueryCompiler[A]
   )(
     tag: String
   )(
     matchToRange: A => Option[B]
-  ) = (pc, PartialCompiler.pos).tupled.emap { case (i, range) =>
+  ) = (pc, QueryCompiler.pos).tupled.emap { case (i, range) =>
     matchToRange(i)
       .toRightIor(
         CompilationError
@@ -122,11 +122,11 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
       .toIorNec
   }
 
-  def primitive[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]): PartialCompiler[P] =
+  def primitive[P](shapeId: ShapeId, hints: Hints, tag: Primitive[P]): QueryCompiler[P] =
     tag match {
       case PString => string
       case PBoolean =>
-        PartialCompiler
+        QueryCompiler
           .typeCheck(NodeKind.Bool) { case b @ BooleanLiteral(_) => b }
           .map(_.value.value)
       case PUnit     => struct(shapeId, hints, Vector.empty, _ => ())
@@ -138,7 +138,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
       case PDouble   => checkRange(integer)("double")(_.toDoubleOption)
       case PDocument => document
       case PBlob =>
-        (string, PartialCompiler.pos).tupled.emap { case (s, range) =>
+        (string, QueryCompiler.pos).tupled.emap { case (s, range) =>
           Either
             .catchNonFatal(Base64.getDecoder().decode(s))
             .map(ByteArray(_))
@@ -182,7 +182,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
         }
     }
 
-  private val integer: PartialCompiler[String] = PartialCompiler
+  private val integer: QueryCompiler[String] = QueryCompiler
     .typeCheck(NodeKind.IntLiteral) { case i @ IntLiteral(_) => i }
     .map(_.value.value)
 
@@ -191,7 +191,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
     hints: Hints,
     tag: CollectionTag[C],
     member: Schema[A],
-  ): PartialCompiler[C[A]] =
+  ): QueryCompiler[C[A]] =
     tag match {
       case SetTag =>
         val memberToDoc = Document.Encoder.fromSchema(member)
@@ -227,11 +227,11 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
     hints: Hints,
     key: Schema[K],
     value: Schema[V],
-  ): PartialCompiler[Map[K, V]] = {
+  ): QueryCompiler[Map[K, V]] = {
     val fk = key.compile(this)
     val fv = value.compile(this)
 
-    PartialCompiler
+    QueryCompiler
       .typeCheck(NodeKind.Struct) { case s @ Struct(_) => s }
       .emap { struct =>
         val fields = struct.value.fields.value.value
@@ -254,7 +254,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
     hints: Hints,
     fieldsRaw: Vector[SchemaField[S, _]],
     make: IndexedSeq[Any] => S,
-  ): PartialCompiler[S] = {
+  ): QueryCompiler[S] = {
     val fields = fieldsRaw.map(_.mapK(this))
 
     val validFields = fields.map(_.label)
@@ -263,7 +263,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
         f.hints.get(api.Deprecated).tupleLeft(f.label)
       }.toMap
 
-    PartialCompiler
+    QueryCompiler
       .typeCheck(NodeKind.Struct) { case s @ Struct(_) => s }
       .emap { struct =>
         // this is a list to keep the original type's ordering
@@ -276,7 +276,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
 
         val presentKeys = struct.value.fields.value.keys
 
-        val extraFieldErrors: PartialCompiler.Result[Unit] = presentKeys
+        val extraFieldErrors: QueryCompiler.Result[Unit] = presentKeys
           .filterNot(field => validFields.contains(field.value.text))
           .map { unexpectedKey =>
             CompilationError.error(
@@ -290,7 +290,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
           .toBothLeft(())
           .combine(Ior.right(()))
 
-        val deprecatedFieldWarnings: PartialCompiler.Result[Unit] = presentKeys
+        val deprecatedFieldWarnings: QueryCompiler.Result[Unit] = presentKeys
           .flatMap { key =>
             deprecatedFields.get(key.value.text).map { info =>
               CompilationError.deprecation(info, key.range)
@@ -334,22 +334,22 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
     hints: Hints,
     alternatives: Vector[Alt[Schema, U, _]],
     dispatcher: Alt.Dispatcher[Schema, U],
-  ): PartialCompiler[U] = {
+  ): QueryCompiler[U] = {
     val alternativesCompiled = alternatives.map(_.mapK(this)).groupBy(_.label).map(_.map(_.head))
     val deprecatedAlternativeLabels =
       alternatives.flatMap(alt => alt.hints.get(api.Deprecated).tupleLeft(alt.label)).toMap
 
     val labels = NonEmptyList.fromListUnsafe(alternatives.toList).map(_.label)
 
-    PartialCompiler
+    QueryCompiler
       // todo: should say it's a union
       .typeCheck(NodeKind.Struct) { case s @ Struct(_) => s }
       .emap {
         case s if s.value.fields.value.size == 1 =>
           val defs = s.value.fields.value
           def go[A](
-            alt: Alt[PartialCompiler, U, A]
-          ): PartialCompiler[U] = alt.instance.map(alt.inject)
+            alt: Alt[QueryCompiler, U, A]
+          ): QueryCompiler[U] = alt.instance.map(alt.inject)
 
           val (k, v) = defs.head
           val op =
@@ -363,7 +363,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
               )
               .toIorNec
 
-          val deprecationWarning: PartialCompiler.Result[Unit] = deprecatedAlternativeLabels
+          val deprecationWarning: QueryCompiler.Result[Unit] = deprecatedAlternativeLabels
             .get(k.value.text)
             .map { info =>
               CompilationError
@@ -403,17 +403,17 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
   def biject[A, B](
     schema: Schema[A],
     bijection: Bijection[A, B],
-  ): PartialCompiler[B] = schema.compile(this).map(bijection.apply)
+  ): QueryCompiler[B] = schema.compile(this).map(bijection.apply)
 
   def refine[A, B](
     schema: Schema[A],
     refinement: Refinement[A, B],
-  ): PartialCompiler[B] = surject(schema.compile(this), refinement)
+  ): QueryCompiler[B] = surject(schema.compile(this), refinement)
 
   private def surject[A, B](
-    pc: PartialCompiler[A],
+    pc: QueryCompiler[A],
     refinement: Refinement[A, B],
-  ): PartialCompiler[B] = (pc, PartialCompiler.pos).tupled.emap { case (a, pos) =>
+  ): QueryCompiler[B] = (pc, QueryCompiler.pos).tupled.emap { case (a, pos) =>
     refinement(a)
       .toIor
       .leftMap { msg =>
@@ -425,21 +425,21 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
       .toIorNec
   }
 
-  def lazily[A](suspend: Lazy[Schema[A]]): PartialCompiler[A] = {
+  def lazily[A](suspend: Lazy[Schema[A]]): QueryCompiler[A] = {
     val it = suspend.map(_.compile(this))
 
     it.value.compile(_)
   }
 
   val stringLiteral =
-    PartialCompiler.typeCheck(NodeKind.StringLiteral) { case StringLiteral(s) => s }
+    QueryCompiler.typeCheck(NodeKind.StringLiteral) { case StringLiteral(s) => s }
 
-  val document: PartialCompiler[Document] =
+  val document: QueryCompiler[Document] =
     _.value match {
-      case BooleanLiteral(value) => Document.fromBoolean(value).pure[PartialCompiler.Result]
+      case BooleanLiteral(value) => Document.fromBoolean(value).pure[QueryCompiler.Result]
       case IntLiteral(value) =>
-        Document.fromBigDecimal(BigDecimal(value)).pure[PartialCompiler.Result]
-      case StringLiteral(value) => Document.fromString(value).pure[PartialCompiler.Result]
+        Document.fromBigDecimal(BigDecimal(value)).pure[QueryCompiler.Result]
+      case StringLiteral(value) => Document.fromString(value).pure[QueryCompiler.Result]
       // parTraverse in this file isn't going to work like you think it will
       case Listed(values) => values.value.parTraverse(document.compile(_)).map(Document.array(_))
       case Struct(fields) =>
@@ -458,7 +458,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
     hints: Hints,
     values: List[EnumValue[E]],
     total: E => EnumValue[E],
-  ): PartialCompiler[E] = (string, PartialCompiler.pos).tupled.emap { case (name, range) =>
+  ): QueryCompiler[E] = (string, QueryCompiler.pos).tupled.emap { case (name, range) =>
     values
       .foreach(v =>
         System
@@ -474,7 +474,7 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
       .find(_.name == name)
 
     (byName, byValue) match {
-      case (Some(v), _) => v.value.pure[PartialCompiler.Result]
+      case (Some(v), _) => v.value.pure[QueryCompiler.Result]
 
       case (None, Some(v)) =>
         Ior.bothNec(CompilationError.warning(EnumFallback(v.name), range).deprecated, v.value)
@@ -486,15 +486,15 @@ object QueryCompilerInternal extends SchemaVisitor[PartialCompiler] {
   }
 
   private def listWithPos[S](
-    fs: PartialCompiler[S]
-  ): PartialCompiler[List[(S, SourceRange)]] = PartialCompiler
+    fs: QueryCompiler[S]
+  ): QueryCompiler[List[(S, SourceRange)]] = QueryCompiler
     .typeCheck(NodeKind.Listed) { case l @ Listed(_) => l }
     .emap(
       _.value
         .values
         .value
         .parTraverse { item =>
-          (fs, PartialCompiler.pos).tupled.compile(item)
+          (fs, QueryCompiler.pos).tupled.compile(item)
         }
     )
 

--- a/core/src/main/scala/playground/run.scala
+++ b/core/src/main/scala/playground/run.scala
@@ -113,7 +113,7 @@ private class ServiceCompiler[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _]](
   private def compileEndpoint[In, Err, Out](
     e: Endpoint[Op, In, Err, Out, _, _]
   ): WithSource[InputNode[WithSource]] => IorNel[CompilationError, CompiledInput] = {
-    val inputCompiler = e.input.compile(QueryCompiler.full)
+    val inputCompiler = e.input.compile(QueryCompilerVisitor.full)
     val outputEncoder = NodeEncoder.derive(e.output)
     val errorEncoder = e.errorable.map(e => NodeEncoder.derive(e.error))
 

--- a/core/src/main/scala/playground/smithyutil/AddDynamicRefinements.scala
+++ b/core/src/main/scala/playground/smithyutil/AddDynamicRefinements.scala
@@ -1,0 +1,82 @@
+package playground.smithyutil
+
+import cats.implicits._
+import smithy.api
+import smithy4s.Refinement
+import smithy4s.RefinementProvider
+import smithy4s.Surjection
+import smithy4s.schema.CollectionTag.IndexedSeqTag
+import smithy4s.schema.CollectionTag.ListTag
+import smithy4s.schema.CollectionTag.SetTag
+import smithy4s.schema.CollectionTag.VectorTag
+import smithy4s.schema.Primitive.PBigDecimal
+import smithy4s.schema.Primitive.PBigInt
+import smithy4s.schema.Primitive.PBlob
+import smithy4s.schema.Primitive.PBoolean
+import smithy4s.schema.Primitive.PByte
+import smithy4s.schema.Primitive.PDocument
+import smithy4s.schema.Primitive.PDouble
+import smithy4s.schema.Primitive.PFloat
+import smithy4s.schema.Primitive.PInt
+import smithy4s.schema.Primitive.PLong
+import smithy4s.schema.Primitive.PShort
+import smithy4s.schema.Primitive.PString
+import smithy4s.schema.Primitive.PTimestamp
+import smithy4s.schema.Primitive.PUUID
+import smithy4s.schema.Primitive.PUnit
+import smithy4s.schema.Schema
+import smithy4s.schema.Schema.CollectionSchema
+import smithy4s.schema.Schema.MapSchema
+import smithy4s.schema.Schema.PrimitiveSchema
+import smithy4s.~>
+
+object AddDynamicRefinements extends (Schema ~> Schema) {
+
+  private def void[C, A](
+    underlying: RefinementProvider[C, A, _]
+  ): RefinementProvider.Simple[C, A] =
+    Refinement
+      .drivenBy[C]
+      .contextual[A, A](c => Surjection(v => underlying.make(c).apply(v).as(v), identity))(
+        underlying.tag
+      )
+
+  private implicit class SchemaOps[A](schema: Schema[A]) {
+    def reifyHint[B](implicit rp: RefinementProvider[B, A, _]): Schema[A] =
+      schema.hints.get(rp.tag).fold(schema)(schema.validated(_)(void(rp)))
+  }
+
+  private def collection[C[_], A](
+    schema: Schema.CollectionSchema[C, A]
+  ): Schema[C[A]] =
+    schema.tag match {
+      case ListTag   => schema.reifyHint(RefinementProvider.iterableLengthConstraint[List, A])
+      case VectorTag => schema.reifyHint(RefinementProvider.iterableLengthConstraint[Vector, A])
+      case SetTag    => schema.reifyHint(RefinementProvider.iterableLengthConstraint[Set, A])
+      case IndexedSeqTag =>
+        schema.reifyHint(RefinementProvider.iterableLengthConstraint[IndexedSeq, A])
+    }
+
+  def apply[A](schema: Schema[A]): Schema[A] =
+    schema match {
+      case PrimitiveSchema(_, _, tag) =>
+        tag match {
+          case PString     => schema.reifyHint[api.Length].reifyHint[api.Pattern]
+          case PByte       => schema.reifyHint[api.Range]
+          case PShort      => schema.reifyHint[api.Range]
+          case PInt        => schema.reifyHint[api.Range]
+          case PLong       => schema.reifyHint[api.Range]
+          case PFloat      => schema.reifyHint[api.Range]
+          case PDouble     => schema.reifyHint[api.Range]
+          case PBigInt     => schema.reifyHint[api.Range]
+          case PBigDecimal => schema.reifyHint[api.Range]
+          case PBlob       => schema.reifyHint[api.Length]
+          case PUnit | PTimestamp | PDocument | PBoolean | PUUID => schema
+        }
+
+      case c: CollectionSchema[_, _] => collection(c)
+      case m: MapSchema[_, _]        => m.reifyHint[api.Length]
+      case _                         => schema
+    }
+
+}

--- a/core/src/main/scala/playground/smithyutil/TransitiveCompiler.scala
+++ b/core/src/main/scala/playground/smithyutil/TransitiveCompiler.scala
@@ -1,0 +1,33 @@
+package playground.smithyutil
+
+import smithy4s.schema.Schema
+import smithy4s.schema.Schema.BijectionSchema
+import smithy4s.schema.Schema.CollectionSchema
+import smithy4s.schema.Schema.EnumerationSchema
+import smithy4s.schema.Schema.LazySchema
+import smithy4s.schema.Schema.MapSchema
+import smithy4s.schema.Schema.PrimitiveSchema
+import smithy4s.schema.Schema.RefinementSchema
+import smithy4s.schema.Schema.StructSchema
+import smithy4s.schema.Schema.UnionSchema
+import smithy4s.~>
+
+// Applies the underlying transformation on each node of the schema that has its own hints
+final class TransitiveCompiler(underlying: Schema ~> Schema) extends (Schema ~> Schema) {
+
+  def apply[A](fa: Schema[A]): Schema[A] =
+    fa match {
+      case e @ EnumerationSchema(_, _, _, _) => underlying(e)
+      case p @ PrimitiveSchema(_, _, _)      => underlying(p)
+      case u @ UnionSchema(_, _, _, _) =>
+        underlying(u.copy(alternatives = u.alternatives.map(_.mapK(this))))
+      case BijectionSchema(s, bijection) => BijectionSchema(this(s), bijection)
+      case LazySchema(suspend)           => LazySchema(suspend.map(this.apply))
+      case RefinementSchema(underlying, refinement) =>
+        RefinementSchema(this(underlying), refinement)
+      case c @ CollectionSchema(_, _, _, _) => c.copy(member = this(c.member))
+      case m @ MapSchema(_, _, _, _) => underlying(m.copy(key = this(m.key), value = this(m.value)))
+      case s @ StructSchema(_, _, _, _) => underlying(s.copy(fields = s.fields.map(_.mapK(this))))
+    }
+
+}

--- a/core/src/test/scala/playground/smithyql/CompilationTests.scala
+++ b/core/src/test/scala/playground/smithyql/CompilationTests.scala
@@ -20,8 +20,8 @@ import playground.CompilationError
 import playground.CompilationErrorDetails
 import playground.CompilationFailed
 import playground.DiagnosticTag
-import playground.PartialCompiler
 import playground.QueryCompiler
+import playground.QueryCompilerVisitor
 import smithy.api
 import smithy.api.TimestampFormat
 import smithy4s.Document
@@ -51,8 +51,8 @@ object CompilationTests extends SimpleIOSuite with Checkers {
   import DSL._
 
   def compile[A: smithy4s.Schema](
-    in: PartialCompiler.WAST
-  ) = implicitly[smithy4s.Schema[A]].compile(QueryCompiler.full).compile(in)
+    in: QueryCompiler.WAST
+  ) = implicitly[smithy4s.Schema[A]].compile(QueryCompilerVisitor.full).compile(in)
 
   val dynamicModel = DynamicSchemaIndex.load(
     Model(
@@ -556,7 +556,7 @@ object CompilationTests extends SimpleIOSuite with Checkers {
 
     val result = compile[Power](WithSource.liftId("Wind".mapK(WithSource.liftId)).withRange(aRange))
 
-    val expected: PartialCompiler.Result[Power] = Ior.both(
+    val expected: QueryCompiler.Result[Power] = Ior.both(
       NonEmptyChain.one(
         CompilationError
           .warning(
@@ -731,10 +731,10 @@ object CompilationTests extends SimpleIOSuite with Checkers {
   }
 
   implicit val arbInputNode: Arbitrary[InputNode[WithSource]] = Arbitrary(genInputNode(2))
-  implicit val showWast: Show[PartialCompiler.WAST] = Show.fromToString
+  implicit val showWast: Show[QueryCompiler.WAST] = Show.fromToString
 
   test("anything to document matches") {
-    forall((wast: PartialCompiler.WAST) =>
+    forall((wast: QueryCompiler.WAST) =>
       assert(
         compile[Document](wast)(Schema.document).isRight
       )

--- a/core/src/test/smithy/demo.smithy
+++ b/core/src/test/smithy/demo.smithy
@@ -71,7 +71,8 @@ structure CreateHeroInput {
   doc: Document
 }
 
-set FriendSet {
+@uniqueItems
+list FriendSet {
   member: Hero
 }
 
@@ -195,7 +196,8 @@ list Ints {
   member: Integer
 }
 
-set IntSet {
+@uniqueItems
+list IntSet {
   member: Integer
 }
 


### PR DESCRIPTION
- Refactor: split out classes from QueryCompiler.scala
- QueryCompiler -> QueryCompilerVisitor, PartialCompiler -> QueryCompiler
- Extract QueryCompiler to its own file
