### PR TITLE
Encode enums by name

### DIFF
--- a/core/src/main/scala/playground/NodeEncoderVisitor.scala
+++ b/core/src/main/scala/playground/NodeEncoderVisitor.scala
@@ -147,7 +147,7 @@ object NodeEncoderVisitor extends SchemaVisitor[NodeEncoder] { self =>
     hints: Hints,
     values: List[EnumValue[E]],
     total: E => EnumValue[E],
-  ): NodeEncoder[E] = string.contramap(total(_).stringValue)
+  ): NodeEncoder[E] = string.contramap(total(_).name)
 
   def struct[S](
     shapeId: ShapeId,

--- a/core/src/test/scala/playground/NodeEncoderTests.scala
+++ b/core/src/test/scala/playground/NodeEncoderTests.scala
@@ -14,6 +14,7 @@ import smithy4s.ByteArray
 import playground.smithyql.StringLiteral
 import smithy4s.Document
 import playground.smithyql.NullLiteral
+import demo.smithy.Power
 
 object NodeEncoderTests extends FunSuite {
 
@@ -47,6 +48,10 @@ object NodeEncoderTests extends FunSuite {
 
   test("simple struct") {
     assertEncodes(Good.schema, Good(42), struct("howGood" -> 42))
+  }
+
+  test("enum") {
+    assertEncodes(Power.schema, Power.ICE, "ICE")
   }
 
   test("union") {


### PR DESCRIPTION
Fixes a bug in which enum values would be serialized in the legacy format - using the string value. Now they'll be serialized using the name (same as they're being decoded by default)