### PR TITLE
Unify experience for parse errors

### DIFF
--- a/modules/core/src/main/scala/playground/CompilationError.scala
+++ b/modules/core/src/main/scala/playground/CompilationError.scala
@@ -90,7 +90,8 @@ sealed trait CompilationErrorDetails extends Product with Serializable {
 
   def render: String =
     this match {
-      case Message(text)        => text
+      case Message(text)                 => text
+      case ParseError(expectationString) => s"Parsing failure: expected ${expectationString}"
       case DeprecatedItem(info) => "Deprecated" + CompilationErrorDetails.deprecationString(info)
       case InvalidUUID          => "Invalid UUID"
       case InvalidBlob          => "Invalid blob, expected base64-encoded string"
@@ -167,6 +168,8 @@ object CompilationErrorDetails {
       CompilationErrorDetails.ConflictingServiceReference(refs)
 
   }
+
+  final case class ParseError(expectationString: String) extends CompilationErrorDetails
 
   // todo: remove
   final case class Message(text: String) extends CompilationErrorDetails


### PR DESCRIPTION
Right now, parse error expectations have a different rendering in tests and in the actual editor.

This unifies the experience and makes some cosmetic changes, as well as special-casing for some common expectations.

Before:

<img width="772" alt="image" src="https://user-images.githubusercontent.com/894884/196049325-55950786-99d0-4bd0-9508-79dcbcd55852.png">

After:

<img width="897" alt="image" src="https://user-images.githubusercontent.com/894884/196049334-f2c05ba5-8b43-4173-a1cf-a245c44a0fc4.png">
