### PR TITLE
More flexible plugin interface

### DIFF
--- a/modules/core/src/main/scala/playground/OperationRunner.scala
+++ b/modules/core/src/main/scala/playground/OperationRunner.scala
@@ -16,6 +16,7 @@ import org.http4s.Uri
 import org.http4s.client.Client
 import playground._
 import playground.plugins.PlaygroundPlugin
+import playground.plugins.SimpleHttpBuilder
 import playground.smithyql.InputNode
 import playground.smithyql.QualifiedIdentifier
 import playground.smithyql.Query
@@ -30,7 +31,6 @@ import smithy4s.aws.AwsClient
 import smithy4s.aws.AwsEnvironment
 import smithy4s.aws.AwsOperationKind
 import smithy4s.dynamic.DynamicSchemaIndex
-import smithy4s.http4s.SimpleProtocolBuilder
 import smithy4s.http4s.SimpleRestJsonBuilder
 import smithy4s.schema.Schema
 
@@ -174,19 +174,19 @@ object OperationRunner {
         }
 
       private def simpleFromBuilder(
-        builder: SimpleProtocolBuilder[_]
+        builder: SimpleHttpBuilder
       ): IorNel[Issue, smithy4s.Interpreter[Op, F]] =
         Either
           .catchNonFatal {
-            builder(service)
+            builder
               .client(
+                service,
                 dynamicBaseUri[F](
                   baseUri.flatTap { uri =>
                     std.Console[F].println(s"Using base URI: $uri")
                   }
-                ).apply(client)
+                ).apply(client),
               )
-              .use
           }
           .leftMap(Issue.Other(_))
           .flatMap {
@@ -239,10 +239,10 @@ object OperationRunner {
 
       val runners: NonEmptyList[IorNel[Issue, OperationRunner[F]]] = NonEmptyList
         .of(
-          simpleFromBuilder(SimpleRestJsonBuilder),
+          simpleFromBuilder(SimpleHttpBuilder.fromSimpleProtocolBuilder(SimpleRestJsonBuilder)),
           awsInterpreter,
         )
-        .concat(plugins.flatMap(_.http4sBuilders).map(simpleFromBuilder))
+        .concat(plugins.flatMap(_.simpleBuilders).map(simpleFromBuilder))
         .append(stdlibRunner)
         .map(
           _.map { interpreter =>

--- a/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
@@ -12,9 +12,7 @@ import playground.BuildConfig
 import playground.plugins.PlaygroundPlugin
 
 import java.net.URLClassLoader
-import java.util.ServiceLoader
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
 
 trait PluginResolver[F[_]] {
 
@@ -78,13 +76,7 @@ object PluginResolver {
                   getClass().getClassLoader(),
                 )
 
-              ServiceLoader
-                .load(
-                  classOf[PlaygroundPlugin],
-                  classLoader,
-                )
-                .asScala
-                .toList
+              PlaygroundPlugin.getAllPlugins(classLoader)
             }
           }
 

--- a/modules/plugin-core/src/main/scala/playground/plugins/PlaygroundPlugin.scala
+++ b/modules/plugin-core/src/main/scala/playground/plugins/PlaygroundPlugin.scala
@@ -1,7 +1,43 @@
 package playground.plugins
 
 import smithy4s.http4s.SimpleProtocolBuilder
+import smithy4s.Service
+import org.http4s.client.Client
+import smithy4s.UnsupportedProtocolError
+import smithy4s.Monadic
+import cats.effect.Concurrent
 
 trait PlaygroundPlugin {
-  def http4sBuilders: List[SimpleProtocolBuilder[_]]
+  @deprecated("Implement simpleBuilders instead", "0.5.2")
+  def http4sBuilders: List[SimpleProtocolBuilder[_]] = Nil
+
+  def simpleBuilders: List[SimpleHttpBuilder] = http4sBuilders.map(
+    SimpleHttpBuilder.fromSimpleProtocolBuilder
+  )
+
+}
+
+/** A more flexible interface for SimpleProtocolBuilder-like things.
+  */
+trait SimpleHttpBuilder {
+
+  def client[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]: Concurrent](
+    service: Service[Alg, Op],
+    backend: Client[F],
+  ): Either[UnsupportedProtocolError, Monadic[Alg, F]]
+
+}
+
+object SimpleHttpBuilder {
+
+  def fromSimpleProtocolBuilder(builder: SimpleProtocolBuilder[_]): SimpleHttpBuilder =
+    new SimpleHttpBuilder {
+
+      def client[Alg[_[_, _, _, _, _]], Op[_, _, _, _, _], F[_]: Concurrent](
+        service: Service[Alg, Op],
+        backend: Client[F],
+      ): Either[UnsupportedProtocolError, Monadic[Alg, F]] = builder(service).client(backend).use
+
+    }
+
 }

--- a/modules/plugin-core/src/main/scala/playground/plugins/PlaygroundPlugin.scala
+++ b/modules/plugin-core/src/main/scala/playground/plugins/PlaygroundPlugin.scala
@@ -6,6 +6,8 @@ import org.http4s.client.Client
 import smithy4s.UnsupportedProtocolError
 import smithy4s.Monadic
 import cats.effect.Concurrent
+import java.util.ServiceLoader
+import scala.jdk.CollectionConverters._
 
 trait PlaygroundPlugin {
   @deprecated("Implement simpleBuilders instead", "0.5.2")
@@ -14,6 +16,19 @@ trait PlaygroundPlugin {
   def simpleBuilders: List[SimpleHttpBuilder] = http4sBuilders.map(
     SimpleHttpBuilder.fromSimpleProtocolBuilder
   )
+
+}
+
+object PlaygroundPlugin {
+
+  def getAllPlugins(loader: ClassLoader): List[PlaygroundPlugin] =
+    ServiceLoader
+      .load(
+        classOf[PlaygroundPlugin],
+        loader,
+      )
+      .asScala
+      .toList
 
 }
 


### PR DESCRIPTION
Binary compatible with previous versions.

I intend to publish this as 0.5.2 and remove the `http4sBuilders` method in 0.6.0 (binary breaking) - heads up @daddykotex @lewisjkl @yisraelU (changes on your side would be minimal)