### PR TITLE
Remove redundant supervisor

### DIFF
--- a/modules/lsp/src/main/scala/playground/lsp/ServerBuilder.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/ServerBuilder.scala
@@ -3,7 +3,6 @@ package playground.lsp
 import cats.effect.implicits._
 import cats.effect.kernel.Async
 import cats.effect.std
-import cats.effect.std.Supervisor
 import cats.implicits._
 import org.http4s.client.Client
 import org.http4s.client.middleware.Logger
@@ -49,10 +48,8 @@ object ServerBuilder {
       client <- makeClient
       awsEnv <- AwsEnvironment.default(AwsHttp4sBackend(client), AwsRegion.US_EAST_1).memoize
       tdm <- TextDocumentManager.instance[F].toResource
-      sup <- Supervisor[F]
     } yield new ServerBuilder[F] {
       private implicit val textManager: TextDocumentManager[F] = tdm
-      private implicit val supervisor: Supervisor[F] = sup
 
       def build(buildInfo: BuildLoader.Loaded, loader: ServerLoader[F]): F[LanguageServer[F]] =
         for {


### PR DESCRIPTION
Since https://github.com/kubukoz/smithy-playground/pull/173, all notifications are supervised by default thanks to being called in a `Dispatcher` - this means we can pretend everything's happening synchronously.