### PR TITLE
Support maven.repositories / maven.dependencies

### DIFF
--- a/modules/core/src/main/smithy/self.smithy
+++ b/modules/core/src/main/smithy/self.smithy
@@ -5,6 +5,7 @@ namespace playground
 structure BuildConfig {
   mavenDependencies: Strings = [],
   mavenRepositories: Strings = [],
+  maven: MavenConfig,
   imports: Strings = [],
   plugins: Plugins
 }
@@ -19,3 +20,15 @@ structure SmithyPlaygroundPluginConfig {
 }
 
 list Strings { member: String }
+
+structure MavenConfig {
+  dependencies: Strings = [],
+  repositories: Repositories = []
+}
+
+list Repositories { member: Repository }
+
+structure Repository {
+  @required
+  url: String
+}

--- a/modules/lsp/src/main/scala/playground/lsp/BuildLoader.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/BuildLoader.scala
@@ -92,8 +92,12 @@ object BuildLoader {
                       .toFile()
                   )
                   .toSet,
-              dependencies = loaded.config.mavenDependencies,
-              repositories = loaded.config.mavenRepositories,
+              dependencies =
+                loaded.config.mavenDependencies ++ loaded.config.maven.foldMap(_.dependencies),
+              repositories =
+                loaded
+                  .config
+                  .mavenRepositories ++ loaded.config.maven.foldMap(_.repositories).map(_.url),
               transformers = Nil,
               // this should be false really
               // https://github.com/kubukoz/smithy-playground/pull/140

--- a/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
@@ -26,7 +26,7 @@ trait PluginResolver[F[_]] {
       .plugins
       .flatMap(_.smithyPlayground)
       .foldMap(_.extensions),
-    config.mavenRepositories,
+    config.mavenRepositories ++ config.maven.foldMap(_.repositories).map(_.url),
   )
 
 }
@@ -60,7 +60,7 @@ object PluginResolver {
 
         (depsF, reposF)
           .mapN { (deps, repos) =>
-            Fetch(FileCache[Task]().noCredentials.withTtl(1.hour))
+            Fetch(FileCache[Task]().withTtl(1.hour))
               .addDependencies(deps: _*)
               .addRepositories(repos: _*)
           }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
-addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.16.8")
+addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.16.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 


### PR DESCRIPTION
Closes #137.

Also removes a `.noCredentials` on the coursier cache, as I don't really think it was ever necessary. In fact, it is a problem now (see https://github.com/disneystreaming/smithy4s/pull/632 for an upstream change).