### PR TITLE
Bump coursier to 2.1.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val lsp = module("lsp")
       "io.circe" %% "circe-core" % "0.14.3",
       "org.http4s" %% "http4s-ember-client" % "0.23.16",
       "org.http4s" %% "http4s-ember-server" % "0.23.16" % Test,
-      "io.get-coursier" %% "coursier" % "2.0.16",
+      "io.get-coursier" %% "coursier" % "2.1.0-RC2",
       "org.typelevel" %% "cats-tagless-macros" % "0.14.0",
     ),
     buildInfoPackage := "playground.lsp.buildinfo",


### PR DESCRIPTION
Includes a deeply missed fix: [coursier/coursier@`8a9e9ff` (#2541)](https://github.com/coursier/coursier/pull/2541/commits/8a9e9ff00670b2f1ccb5c996344edfca11e5fc9c) https://github.com/coursier/coursier/pull/2541