### PR TITLE
ModelLoader revamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3.2.0
     - uses: cachix/install-nix-action@v18

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Currently available as a LSP server with a client implementation for VS Code.
   // To access non-standard Maven repositories
   "mavenRepositories": [
     "https://<path-to-artifactory>"
-  ]
+  ],
+  // for Playground plugins
+  "smithyPlayground": {
+    "extensions": [
+      "com.kubukoz::playground-extension:0.0.1"
+    ]
+  }
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ lazy val lsp = module("lsp")
     buildInfoKeys ++= Seq(version, scalaBinaryVersion),
     Smithy4sCodegenPlugin.defaultSettings(Test),
     Test / smithy4sSmithyLibrary := false,
-    test := {
+    (Test / test) := {
       (pluginCore / publishLocal).value
       (pluginSample / publishLocal).value
 

--- a/modules/core/src/main/scala/playground/OperationRunner.scala
+++ b/modules/core/src/main/scala/playground/OperationRunner.scala
@@ -269,7 +269,7 @@ object OperationRunner {
           simpleFromBuilder(SimpleHttpBuilder.fromSimpleProtocolBuilder(SimpleRestJsonBuilder)),
           awsInterpreter,
         )
-        .concat(plugins.flatMap(_.simpleBuilders).map(simpleFromBuilder))
+        .concat(plugins.flatMap(_.simpleBuilders).map(simpleFromBuilder(_)))
         .append(stdlibRunner)
         .map(
           _.map { interpreter =>

--- a/modules/core/src/main/scala/playground/std/StdlibRuntime.scala
+++ b/modules/core/src/main/scala/playground/std/StdlibRuntime.scala
@@ -18,7 +18,8 @@ object StdlibRuntime {
 
       val random: Random[F] =
         new playground.std.Random[F] {
-          def nextUUID(): F[NextUUIDOutput] = UUIDGen[F].randomUUID.map(NextUUIDOutput(_))
+          def nextUUID(
+          ): F[NextUUIDOutput] = UUIDGen[F].randomUUID.map(_.toString).map(NextUUIDOutput(_))
         }
 
       val clock: Clock[F] =

--- a/modules/core/src/main/smithy/self.smithy
+++ b/modules/core/src/main/smithy/self.smithy
@@ -7,11 +7,6 @@ structure BuildConfig {
   mavenRepositories: Strings = [],
   maven: MavenConfig,
   imports: Strings = [],
-  plugins: Plugins
-}
-
-structure Plugins {
-  @jsonName("smithy-playground")
   smithyPlayground: SmithyPlaygroundPluginConfig
 }
 

--- a/modules/core/src/main/smithy/std.smithy
+++ b/modules/core/src/main/smithy/std.smithy
@@ -2,11 +2,11 @@ $version: "2"
 
 namespace playground.std
 
-use smithy4s.api#UUID
-
 @trait(selector: "service")
 @protocolDefinition
 structure stdlib {}
+
+string UUID
 
 @stdlib
 @documentation("A standard library service providing random generators of data.")

--- a/modules/lsp/src/main/scala/playground/lsp/BuildLoader.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/BuildLoader.scala
@@ -8,7 +8,6 @@ import playground.BuildConfigDecoder
 import playground.ModelReader
 import playground.language.TextDocumentProvider
 import playground.language.Uri
-import smithy4s.codegen.ModelLoader
 import smithy4s.dynamic.DynamicSchemaIndex
 
 trait BuildLoader[F[_]] {
@@ -77,7 +76,7 @@ object BuildLoader {
       def buildSchemaIndex(loaded: BuildLoader.Loaded): F[DynamicSchemaIndex] = Sync[F]
         .interruptibleMany {
           ModelLoader
-            .load(
+            .loadUnsafe(
               specs =
                 loaded
                   .config
@@ -98,14 +97,9 @@ object BuildLoader {
                 loaded
                   .config
                   .mavenRepositories ++ loaded.config.maven.foldMap(_.repositories).map(_.url),
-              transformers = Nil,
-              // this should be false really
-              // https://github.com/kubukoz/smithy-playground/pull/140
-              discoverModels = true,
-              localJars = Nil,
             )
-            ._2
         }
+        .map(_._2)
         .flatMap(ModelReader.buildSchemaIndex[F])
 
     }

--- a/modules/lsp/src/main/scala/playground/lsp/ModelLoader.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/ModelLoader.scala
@@ -1,0 +1,115 @@
+package playground.lsp
+
+// fork of smithy4s's ModelLoader
+
+import coursier._
+import coursier.cache.FileCache
+import coursier.parse.DependencyParser
+import coursier.parse.RepositoryParser
+import coursier.util.Task
+import playground.lsp.buildinfo.BuildInfo
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.loader.ModelAssembler
+import software.amazon.smithy.model.loader.ModelDiscovery
+import software.amazon.smithy.model.loader.ModelManifestException
+
+import java.io.File
+import java.net.URLClassLoader
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+object ModelLoader {
+
+  def loadUnsafe(
+    specs: Set[File],
+    dependencies: List[String],
+    repositories: List[String],
+  ): (ClassLoader, Model) = {
+
+    val dependencyJars = resolveDependencies(dependencies, repositories)
+
+    val modelAssembler: ModelAssembler = Model
+      .assembler()
+      .putProperty(ModelAssembler.DISABLE_JAR_CACHE, true)
+      .pipe(addModelsFromJars(dependencyJars))
+      .pipe(addPlaygroundModels(this.getClass().getClassLoader()))
+      .pipe(addFileImports(specs))
+
+    (
+      new URLClassLoader(
+        dependencyJars.map(_.toURI().toURL()).toArray,
+        getClass().getClassLoader(),
+      ),
+      modelAssembler.assemble().unwrap(),
+    )
+  }
+
+  private def addModelsFromJars(jarFiles: Iterable[File]): ModelAssembler => ModelAssembler =
+    assembler => {
+      val modelsInJars = jarFiles.flatMap { file =>
+        val manifestUrl = ModelDiscovery.createSmithyJarManifestUrl(file.getAbsolutePath())
+        try ModelDiscovery.findModels(manifestUrl).asScala
+        catch {
+          case _: ModelManifestException => Nil
+        }
+      }
+
+      modelsInJars.foreach(assembler.addImport)
+      assembler
+    }
+
+  private def addFileImports(imports: Iterable[File]): ModelAssembler => ModelAssembler =
+    assembler => {
+      imports.foreach(f => assembler.addImport(f.toPath()))
+      assembler
+    }
+
+  private def addPlaygroundModels(
+    classLoader: ClassLoader
+  ): ModelAssembler => ModelAssembler =
+    assembler => {
+      List(
+        "META-INF/smithy/std.smithy"
+      ).map(classLoader.getResource).foreach(assembler.addImport)
+
+      assembler
+    }
+
+  private def resolveDependencies(
+    dependencies: List[String],
+    repositories: List[String],
+  ): List[File] = {
+    val maybeRepos = RepositoryParser.repositories(repositories).either
+    val maybeDeps =
+      DependencyParser
+        .dependencies(
+          dependencies,
+          defaultScalaVersion = BuildInfo.scalaBinaryVersion,
+        )
+        .either
+    val repos =
+      maybeRepos match {
+        case Left(errorMessages) =>
+          throw new IllegalArgumentException(
+            s"Failed to parse repositories with error: $errorMessages"
+          )
+        case Right(r) => r
+      }
+    val deps =
+      maybeDeps match {
+        case Left(errorMessages) =>
+          throw new IllegalArgumentException(
+            s"Failed to parse dependencies with errors: $errorMessages"
+          )
+        case Right(d) => d
+      }
+
+    Fetch(FileCache[Task]().withTtl(1.hour))
+      .addRepositories(repos: _*)
+      .addDependencies(deps: _*)
+      .run()
+      .toList
+  }
+
+}

--- a/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
@@ -1,18 +1,9 @@
 package playground.lsp
 
-import cats.effect.kernel.Async
 import cats.effect.kernel.Sync
 import cats.implicits._
-import coursier._
-import coursier.cache.FileCache
-import coursier.parse.DependencyParser
-import coursier.parse.RepositoryParser
-import coursier.util.Task
 import playground.BuildConfig
 import playground.plugins.PlaygroundPlugin
-
-import java.net.URLClassLoader
-import scala.concurrent.duration._
 
 trait PluginResolver[F[_]] {
 
@@ -22,10 +13,10 @@ trait PluginResolver[F[_]] {
   ): F[List[PlaygroundPlugin]]
 
   def resolveFromConfig(config: BuildConfig): F[List[PlaygroundPlugin]] = resolve(
-    config
-      .plugins
-      .flatMap(_.smithyPlayground)
-      .foldMap(_.extensions),
+    config.mavenDependencies ++ config.maven.foldMap(_.dependencies) ++
+      config
+        .smithyPlayground
+        .foldMap(_.extensions),
     config.mavenRepositories ++ config.maven.foldMap(_.repositories).map(_.url),
   )
 
@@ -35,51 +26,23 @@ object PluginResolver {
 
   def apply[F[_]](implicit F: PluginResolver[F]): PluginResolver[F] = F
 
-  def instance[F[_]: Async]: PluginResolver[F] =
+  def instance[F[_]: Sync]: PluginResolver[F] =
     new PluginResolver[F] {
 
       def resolve(
         artifacts: List[String],
         repositories: List[String],
-      ): F[List[PlaygroundPlugin]] = {
-        val depsF = DependencyParser
-          .dependencies(artifacts, defaultScalaVersion = "2.13")
-          .either
-          .leftMap(errors =>
-            new Throwable("Failed to parse dependencies: " + errors.mkString(", "))
-          )
-          .liftTo[F]
-
-        val reposF = RepositoryParser
-          .repositories(repositories)
-          .either
-          .leftMap(errors =>
-            new Throwable("Failed to parse repositories: " + errors.mkString(", "))
-          )
-          .liftTo[F]
-
-        (depsF, reposF)
-          .mapN { (deps, repos) =>
-            Fetch(FileCache[Task]().withTtl(1.hour))
-              .addDependencies(deps: _*)
-              .addRepositories(repos: _*)
-          }
-          .flatMap { fetch =>
-            Async[F].fromFuture(Sync[F].delay(fetch.future()))
-          }
-          .flatMap { files =>
-            Sync[F].delay {
-              val classLoader =
-                new URLClassLoader(
-                  files.map(_.toURI().toURL()).toArray,
-                  getClass().getClassLoader(),
-                )
-
-              PlaygroundPlugin.getAllPlugins(classLoader)
-            }
-          }
-
-      }
+      ): F[List[PlaygroundPlugin]] = Sync[F]
+        .interruptibleMany(
+          ModelLoader
+            .loadUnsafe(
+              specs = Set.empty,
+              dependencies = artifacts,
+              repositories = repositories,
+            )
+            ._1
+        )
+        .map(PlaygroundPlugin.getAllPlugins(_))
 
     }
 

--- a/modules/lsp/src/main/scala/playground/lsp/ServerLoader.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/ServerLoader.scala
@@ -32,7 +32,7 @@ object ServerLoader {
     def fromBuildConfig(bc: BuildConfig): WorkspaceStats = WorkspaceStats(
       importCount = bc.imports.size,
       dependencyCount = bc.mavenDependencies.size,
-      pluginCount = bc.plugins.flatMap(_.smithyPlayground).foldMap(_.extensions).size,
+      pluginCount = bc.smithyPlayground.foldMap(_.extensions).size,
     )
 
   }

--- a/modules/lsp/src/test/resources/test-workspace/smithy-build.json
+++ b/modules/lsp/src/test/resources/test-workspace/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "imports": ["./weather.smithy", "./no-runner.smithy"],
-  "mavenDependencies-ignored": [
-    "com.disneystreaming.smithy4s:smithy4s-protocol:latest.release"
+  "mavenDependencies": [
+    "com.disneystreaming.smithy4s:smithy4s-protocol:0.16.10"
   ]
 }

--- a/modules/lsp/src/test/scala/playground/lsp/LanguageServerIntegrationTestSharedServer.scala
+++ b/modules/lsp/src/test/scala/playground/lsp/LanguageServerIntegrationTestSharedServer.scala
@@ -44,7 +44,7 @@ object LanguageServerIntegrationTestSharedServer
         ),
       TestClient.MessageLog(
         MessageType.Info,
-        "Loaded Smithy Playground server with 2 imports, 0 dependencies and 0 plugins",
+        "Loaded Smithy Playground server with 2 imports, 1 dependencies and 0 plugins",
       ),
     )
 
@@ -249,8 +249,7 @@ object LanguageServerIntegrationTestSharedServer
       // as there's no need
       .withHost(host"localhost")
       .withPort(port"0")
-      // https://github.com/http4s/http4s/pull/6781
-      .withShutdownTimeout(1.nano)
+      .withShutdownTimeout(Duration.Zero)
       .withHttpApp(
         SimpleRestJsonBuilder
           .routes(

--- a/modules/lsp/src/test/scala/playground/lsp/ModelLoaderTests.scala
+++ b/modules/lsp/src/test/scala/playground/lsp/ModelLoaderTests.scala
@@ -1,0 +1,51 @@
+package playground.lsp
+
+import software.amazon.smithy.model.shapes.ShapeId
+import weaver._
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+
+object ModelLoaderTests extends FunSuite {
+
+  test("Empty loader config can see stdlib") {
+    val result =
+      loadModelEmpty()
+        .getServiceShapes()
+        .asScala
+        .map(_.getId())
+        .toSet
+
+    assert.eql(result.map(_.getName()), Set("Random", "Clock"))
+  }
+
+  test("Empty loader cannot see UUID without a dependency") {
+    val shapeId = ShapeId.from("smithy4s.api#UUID")
+    val result =
+      loadModelEmpty()
+        .getShape(shapeId)
+        .toScala
+
+    assert.same(result, None)
+  }
+
+  test("Loader with dependencies can see external shapes") {
+    val shapeId = ShapeId.from("smithy4s.api#UUID")
+    val result = ModelLoader
+      .loadUnsafe(
+        specs = Set.empty,
+        dependencies = List("com.disneystreaming.smithy4s:smithy4s-protocol:0.16.10"),
+        repositories = Nil,
+      )
+      ._2
+      .expectShape(shapeId)
+
+    assert.same(result.getId(), shapeId)
+  }
+
+  private def loadModelEmpty() =
+    ModelLoader
+      .loadUnsafe(specs = Set.empty, dependencies = Nil, repositories = Nil)
+      ._2
+
+}

--- a/modules/lsp/src/test/scala/playground/lsp/PluginResolverTests.scala
+++ b/modules/lsp/src/test/scala/playground/lsp/PluginResolverTests.scala
@@ -1,0 +1,26 @@
+package playground.lsp
+
+import cats.effect.IO
+import weaver._
+
+object PluginResolverTests extends SimpleIOSuite {
+  test("Empty plugin resolver finds no plugins") {
+    PluginResolver
+      .instance[IO]
+      .resolve(artifacts = Nil, repositories = Nil)
+      .map(assert.same(_, Nil))
+  }
+
+  test("Plugin resolver with a sample plugin artifact finds it") {
+    PluginResolver
+      .instance[IO]
+      .resolve(
+        artifacts = List(
+          "com.kubukoz.playground::plugin-sample:latest.integration"
+        ),
+        repositories = Nil,
+      )
+      .map(_.map(_.getClass().getName()))
+      .map(assert.same(_, List("playground.sample.SamplePlaygroundPlugin")))
+  }
+}

--- a/modules/plugin-sample/src/main/resources/META-INF/services/playground.plugins.PlaygroundPlugin
+++ b/modules/plugin-sample/src/main/resources/META-INF/services/playground.plugins.PlaygroundPlugin
@@ -1,0 +1,1 @@
+playground.sample.SamplePlaygroundPlugin

--- a/modules/plugin-sample/src/main/scala/playground/sample/SamplePlaygroundPlugin.scala
+++ b/modules/plugin-sample/src/main/scala/playground/sample/SamplePlaygroundPlugin.scala
@@ -1,0 +1,8 @@
+package playground.sample
+
+import playground.plugins.PlaygroundPlugin
+import playground.plugins.SimpleHttpBuilder
+
+class SamplePlaygroundPlugin extends PlaygroundPlugin {
+  override def simpleBuilders: List[SimpleHttpBuilder] = Nil
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.2")
 


### PR DESCRIPTION
Extracted from #129.

# Breaking changes

- Move the `plugins.smithy-playground.extensions` key to `smithyPlayground.extensions` - previously it could clash with other Smithy tooling
- Alloy / smithy4s-protocol are no longer included as default dependencies: users will have to add them themselves