### PR TITLE
Bump minimal java to 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently available as a LSP server with a client implementation for VS Code.
 
 ## Usage
 
-1. Make sure you have [Coursier](https://get-coursier.io/docs/cli-installation) available on the PATH as `cs`
+1. Make sure you have [Coursier](https://get-coursier.io/docs/cli-installation) available on the PATH as `cs`, running Java 11 or above
 2. Get the extension from [Marketplace](https://marketplace.visualstudio.com/items?itemName=kubukoz.smithy-playground)
 3. Create a file, `smithy-build.json`. Example:
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ val commonSettings = Seq(
   scalacOptions -= "-Vtype-diffs",
   scalacOptions += "-Wnonunit-statement",
   scalacOptions ++= Seq("-Xsource:3.0"),
-  javacOptions ++= Seq("-source", "8", "-target", "8"),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   mimaFailOnNoPrevious := false,
 )
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,17 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev:
+              let
+                jre = final.openjdk11;
+                jdk = jre;
+              in
+              { inherit jdk jre; })
+          ];
+        };
       in
       {
         devShell = pkgs.mkShell {


### PR DESCRIPTION
This is a consequence of jsoniter switching to 11 [a year ago](https://github.com/plokhotnyuk/jsoniter-scala/pull/860).

We were also using some methods not available on 8 (e.g. `.strip` on strings).