### PR TITLE
Make PluginResolver only fetch dependencies from smithyPlayground.extensions

### DIFF
--- a/modules/lsp/src/main/scala/playground/lsp/ModelLoader.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/ModelLoader.scala
@@ -41,6 +41,23 @@ object ModelLoader {
     )
   }
 
+  def makeClassLoaderForPluginsUnsafe(
+    buildConfig: BuildConfig
+  ): URLClassLoader = {
+    val dependencies = buildConfig.smithyPlayground.foldMap(_.extensions)
+
+    val repositories =
+      buildConfig.mavenRepositories ++
+        buildConfig.maven.foldMap(_.repositories).map(_.url)
+
+    val dependencyJars = resolveDependencies(dependencies, repositories)
+
+    new URLClassLoader(
+      dependencyJars.map(_.toURI().toURL()).toArray,
+      getClass().getClassLoader(),
+    )
+  }
+
   def load(
     specs: Set[File],
     classLoader: URLClassLoader,

--- a/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/PluginResolver.scala
@@ -25,7 +25,7 @@ object PluginResolver {
       def resolve(
         config: BuildConfig
       ): F[List[PlaygroundPlugin]] = Sync[F]
-        .interruptibleMany(ModelLoader.makeClassLoaderUnsafe(config))
+        .interruptibleMany(ModelLoader.makeClassLoaderForPluginsUnsafe(config))
         .map(PlaygroundPlugin.getAllPlugins(_))
 
     }

--- a/modules/lsp/src/test/scala/playground/lsp/PluginResolverTests.scala
+++ b/modules/lsp/src/test/scala/playground/lsp/PluginResolverTests.scala
@@ -2,6 +2,7 @@ package playground.lsp
 
 import cats.effect.IO
 import playground.BuildConfig
+import playground.SmithyPlaygroundPluginConfig
 import weaver._
 
 object PluginResolverTests extends SimpleIOSuite {
@@ -12,7 +13,7 @@ object PluginResolverTests extends SimpleIOSuite {
       .map(assert.same(_, Nil))
   }
 
-  test("Plugin resolver with a sample plugin artifact finds it") {
+  test("Plugin resolver doesn't check maven dependencies") {
     PluginResolver
       .instance[IO]
       .resolve(
@@ -21,6 +22,25 @@ object PluginResolverTests extends SimpleIOSuite {
             "com.kubukoz.playground::plugin-sample:latest.integration"
           ),
           mavenRepositories = Nil,
+        )
+      )
+      .map(assert.same(_, Nil))
+  }
+
+  test("Plugin resolver with a sample plugin artifact finds it") {
+    PluginResolver
+      .instance[IO]
+      .resolve(
+        BuildConfig(
+          mavenDependencies = Nil,
+          mavenRepositories = Nil,
+          smithyPlayground = Some(
+            SmithyPlaygroundPluginConfig(
+              extensions = List(
+                "com.kubukoz.playground::plugin-sample:latest.integration"
+              )
+            )
+          ),
         )
       )
       .map(_.map(_.getClass().getName()))


### PR DESCRIPTION
In #225, a regression was introduced: the plugin resolver switched to only use dependencies from `maven.dependencies` and `mavenDependencies`.

Previously, it was _that_ plus `smithyPlayground.extensions`. Now, it'll be just extensions - I figured that Playground shouldn't encourage people to have Scala dependencies in the normal `dependencies`, as that might unnecessarily increase the amount of jars loaded by other tooling.