### PR TITLE
Update smithy4s to 0.17.11

### DIFF
--- a/modules/core/src/main/scala/playground/OperationRunner.scala
+++ b/modules/core/src/main/scala/playground/OperationRunner.scala
@@ -296,7 +296,7 @@ object OperationRunner {
         )
 
       val getInternal: IorNel[Issue, OperationRunner[F]] = runners.reduce(
-        IorUtils.orElseCombine[NonEmptyList[Issue], OperationRunner[F]]
+        IorUtils.orElseCombine[NonEmptyList[Issue], OperationRunner[F]](_, _)
       )
 
       def get(

--- a/modules/lsp/src/main/scala/playground/lsp/ServerBuilder.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/ServerBuilder.scala
@@ -21,6 +21,8 @@ import smithy4s.aws.AwsEnvironment
 import smithy4s.aws.http4s.AwsHttp4sBackend
 import smithy4s.aws.kernel.AwsRegion
 
+import scala.concurrent.duration._
+
 trait ServerBuilder[F[_]] {
 
   def build(
@@ -58,7 +60,12 @@ object ServerBuilder {
 
     for {
       client <- makeClient
-      awsEnv <- AwsEnvironment.default(AwsHttp4sBackend(client), AwsRegion.US_EAST_1).memoize
+      awsEnv <-
+        AwsEnvironment
+          .default(AwsHttp4sBackend(client), AwsRegion.US_EAST_1)
+          // workaround for https://github.com/disneystreaming/smithy4s/issues/1075
+          .timeout(1.second)
+          .memoize
       tdm <- TextDocumentManager.instance[F].toResource
     } yield new ServerBuilder[F] {
       private implicit val textManager: TextDocumentManager[F] = tdm

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.2")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.3")
 
-addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.17.5")
+addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.17.11")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")


### PR DESCRIPTION
This is important for us because of the AWS credential fix: https://github.com/disneystreaming/smithy4s/pull/1076