### PR TITLE
V2 Parser: Add scanner

### DIFF
--- a/modules/ast/src/test/scala/playground/Assertions.scala
+++ b/modules/ast/src/test/scala/playground/Assertions.scala
@@ -23,7 +23,7 @@ object Assertions extends Expectations.Helpers {
         val stringWithResets = d.show()(conf).linesWithSeparators.map(Console.RESET + _).mkString
 
         failure(
-          s"Diff failed:\n${Console.RESET}(${conf.right("expected")}, ${conf.left("actual")})\n\n" + stringWithResets
+          s"Diff failed:\n${Console.RESET}(${conf.left("expected")}, ${conf.right("actual")})\n\n" + stringWithResets
         )
     }
 

--- a/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
+++ b/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
@@ -23,7 +23,7 @@ sealed trait TokenKind extends Product with Serializable {
 }
 
 object TokenKind {
-  case object KW_IMPORT extends TokenKind
+  // case object KW_IMPORT extends TokenKind
   case object DOT extends TokenKind
   case object COMMA extends TokenKind
   case object HASH extends TokenKind

--- a/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
+++ b/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
@@ -31,6 +31,7 @@ object TokenKind {
   case object RB extends TokenKind
   case object LBR extends TokenKind
   case object RBR extends TokenKind
+  case object COLON extends TokenKind
   case object EQ extends TokenKind
   case object SPACE extends TokenKind
   case object NEWLINE extends TokenKind
@@ -81,6 +82,7 @@ object Scanner {
       ']' -> TokenKind.RB,
       '{' -> TokenKind.LBR,
       '}' -> TokenKind.RBR,
+      ':' -> TokenKind.COLON,
       '=' -> TokenKind.EQ,
     ).orElse {
       case letter if letter.isLetter =>

--- a/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
+++ b/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
@@ -23,7 +23,13 @@ sealed trait TokenKind extends Product with Serializable {
 }
 
 object TokenKind {
-  // case object KW_IMPORT extends TokenKind
+  case object KW_USE extends TokenKind
+  case object KW_SERVICE extends TokenKind
+  case object KW_BOOLEAN extends TokenKind
+  case object KW_NUMBER extends TokenKind
+  case object KW_STRING extends TokenKind
+  case object KW_NULL extends TokenKind
+
   case object DOT extends TokenKind
   case object COMMA extends TokenKind
   case object HASH extends TokenKind

--- a/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
+++ b/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
@@ -87,7 +87,7 @@ object Scanner {
       "false" -> TokenKind.KW_BOOLEAN,
     )
 
-    def readIdent: PartialFunction[Unit, Unit] = {
+    val readIdent: PartialFunction[Unit, Unit] = {
       case _ if remaining.head.isLetter =>
         val (letters, rest) = remaining.span(ch => ch.isLetterOrDigit || ch == '_')
 
@@ -95,6 +95,7 @@ object Scanner {
           case Some(kind) =>
             // we matched a keyword, return it.
             add(kind(letters))
+
           case None =>
             // normal ident
             add(TokenKind.IDENT(letters))
@@ -103,7 +104,7 @@ object Scanner {
         remaining = rest
     }
 
-    def readPunctuation: PartialFunction[Unit, Unit] = simpleTokens(
+    val readPunctuation: PartialFunction[Unit, Unit] = simpleTokens(
       "." -> TokenKind.DOT,
       "," -> TokenKind.COMMA,
       "#" -> TokenKind.HASH,
@@ -115,7 +116,7 @@ object Scanner {
       "=" -> TokenKind.EQ,
     )
 
-    def readOne: PartialFunction[Unit, Unit] = readIdent.orElse(readPunctuation)
+    val readOne: PartialFunction[Unit, Unit] = readIdent.orElse(readPunctuation)
 
     // split "whitespace" string into chains of contiguous newlines OR whitespace characters.
     def whitespaceChains(

--- a/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
+++ b/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
@@ -155,6 +155,8 @@ object Scanner {
       }
     }
 
+    // readOne and friends are all partial functions: this is the current implementation of lookahead.
+    // it's not great, but it kinda works.
     val readOne: PartialFunction[Unit, Unit] = readIdent
       .orElse(readPunctuation)
       .orElse(readStringLiteral)
@@ -229,13 +231,7 @@ object Scanner {
     while (remaining.nonEmpty) {
       val last = remaining
 
-      {
-        val matched = readOne.isDefinedAt(())
-        if (matched)
-          readOne(())
-
-        matched
-      } ||
+      readOne.lift(()).isDefined ||
         eatWhitespace() ||
         eatComments() ||
         eatErrors(): Unit

--- a/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
+++ b/modules/parser/src/main/scala/playground/smithyql/parser/v2/scanner.scala
@@ -1,0 +1,166 @@
+package playground.smithyql.parser.v2.scanner
+
+import cats.kernel.Eq
+import cats.syntax.all.*
+
+case class Token(
+  kind: TokenKind,
+  text: String,
+) {
+  def width: Int = text.length
+}
+
+object Token {
+  implicit val eq: Eq[Token] = Eq.fromUniversalEquals
+}
+
+sealed trait TokenKind extends Product with Serializable {
+
+  def apply(
+    text: String
+  ): Token = Token(this, text)
+
+}
+
+object TokenKind {
+  case object KW_IMPORT extends TokenKind
+  case object DOT extends TokenKind
+  case object COMMA extends TokenKind
+  case object HASH extends TokenKind
+  case object LB extends TokenKind
+  case object RB extends TokenKind
+  case object LBR extends TokenKind
+  case object RBR extends TokenKind
+  case object EQ extends TokenKind
+  case object SPACE extends TokenKind
+  case object NEWLINE extends TokenKind
+  case object IDENT extends TokenKind
+  case object COMMENT extends TokenKind
+  case object Error extends TokenKind
+
+  implicit val eq: Eq[TokenKind] = Eq.fromUniversalEquals
+}
+
+object Scanner {
+
+  /** Entrypoint to scanning text into tokens.
+    *
+    * Always produces an output that can be rendered back to the original text.
+    */
+  def scan(
+    s: String
+  ): List[Token] = {
+    var remaining = s
+    var tokens = List.empty[Token]
+    def add(
+      tok: Token
+    ) = tokens ::= tok
+
+    def readSimple(
+      token: Char,
+      tok: TokenKind,
+    ): PartialFunction[Char, Unit] = { case `token` =>
+      add(tok(token.toString))
+      remaining = remaining.tail
+    }
+
+    def simpleTokens(
+      pairings: (
+        Char,
+        TokenKind,
+      )*
+    ): PartialFunction[Char, Unit] = pairings
+      .map(readSimple.tupled)
+      .reduce(_ orElse _)
+
+    val readOne: PartialFunction[Char, Unit] = simpleTokens(
+      '.' -> TokenKind.DOT,
+      ',' -> TokenKind.COMMA,
+      '#' -> TokenKind.HASH,
+      '[' -> TokenKind.LB,
+      ']' -> TokenKind.RB,
+      '{' -> TokenKind.LBR,
+      '}' -> TokenKind.RBR,
+      '=' -> TokenKind.EQ,
+    ).orElse {
+      case letter if letter.isLetter =>
+        val (letters, rest) = remaining.span(ch => ch.isLetterOrDigit || ch == '_')
+        add(TokenKind.IDENT(letters))
+        remaining = rest
+    }
+
+    // split "whitespace" string into chains of contiguous newlines OR whitespace characters.
+    def whitespaceChains(
+      whitespace: String
+    ): List[Token] = {
+      val isNewline = (ch: Char) => ch == '\n'
+
+      if (whitespace.isEmpty)
+        Nil
+      else if (isNewline(whitespace.head)) {
+        val (nl, rest) = whitespace.span(isNewline)
+        TokenKind.NEWLINE(nl) :: whitespaceChains(rest)
+      } else {
+        val (wsp, rest) = whitespace.span(!isNewline(_))
+        TokenKind.SPACE(wsp) :: whitespaceChains(rest)
+      }
+    }
+
+    def eatWhitespace(
+    ) = {
+      val (wsp, rest) = remaining.span(ch => ch.isWhitespace)
+      if (wsp.isEmpty())
+        false
+      else {
+        whitespaceChains(wsp).foreach(add)
+        remaining = rest
+
+        true
+      }
+    }
+
+    def eatComments(
+    ) =
+      if (!remaining.startsWith("//"))
+        false
+      else {
+        while (remaining.startsWith("//")) {
+          val (comment, rest) = remaining.span(_ != '\n')
+          add(TokenKind.COMMENT(comment))
+          remaining = rest
+        }
+
+        true
+      }
+
+    def eatErrors(
+    ) = {
+      // todo: bug: even if the next character starts a multi-char token, this will consider it an error.
+      // instead, we should rework "readOne" to consume arbitrary constant-length tokens, and also include the possibility that `rest` has comments or whitespace.
+      val (failures, rest) = remaining.span(!readOne.isDefinedAt(_))
+      remaining = rest
+      if (failures.nonEmpty) {
+        add(TokenKind.Error(failures))
+        true
+      } else
+        false
+    }
+
+    while (remaining.nonEmpty) {
+      val last = remaining
+
+      readOne.applyOrElse[Char, Any](
+        remaining.head,
+        (_: Char) =>
+          // nothing matched. Eat whitespace and see if the rest is an error
+          eatWhitespace() || eatComments() || eatErrors(),
+      )
+
+      if (remaining == last)
+        sys.error(s"no progress in the last run! remaining string: $remaining")
+    }
+
+    tokens.reverse
+  }
+
+}

--- a/modules/parser/src/test/scala/playground/smithyql/parser/ParserSuite.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/ParserSuite.scala
@@ -55,6 +55,13 @@ trait ParserSuite extends SimpleIOSuite {
       }
     }
 
+    validTokensTest(testCase, trimWhitespace)
+  }
+
+  private def validTokensTest(
+    testCase: TestCase,
+    trimWhitespace: Boolean,
+  ) =
     test(testCase.name + " (v2 scanner)") {
       testCase.readInput(trimWhitespace).map { input =>
         val scanned = Scanner.scan(input)
@@ -65,11 +72,12 @@ trait ParserSuite extends SimpleIOSuite {
         assert(errors.isEmpty)
       }
     }
-  }
 
+  // invalidTokens: a flag that tells the suite whether the file should contain invalid tokens.
   def loadNegativeParserTests[Alg[_[_]]: SourceParser](
     prefix: String,
     trimWhitespace: Boolean = false,
+    invalidTokens: Boolean,
   ): Unit = loadTestCases("", List("negative", prefix)).foreach { testCase =>
     test(testCase.name) {
       testCase.readInput(trimWhitespace).map { input =>
@@ -79,6 +87,10 @@ trait ParserSuite extends SimpleIOSuite {
         }
       }
     }
+
+    if (!invalidTokens)
+      validTokensTest(testCase, trimWhitespace)
+
   }
 
   private def readText(

--- a/modules/parser/src/test/scala/playground/smithyql/parser/ParserSuite.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/ParserSuite.scala
@@ -10,6 +10,8 @@ import io.circe.Decoder
 import io.circe.syntax._
 import playground.Assertions._
 import playground.smithyql._
+import playground.smithyql.parser.v2.scanner.Scanner
+import playground.smithyql.parser.v2.scanner.TokenKind
 import weaver._
 
 import java.nio.file
@@ -50,6 +52,17 @@ trait ParserSuite extends SimpleIOSuite {
                   }
               }
         }
+      }
+    }
+
+    test(testCase.name + " (v2 scanner)") {
+      testCase.readInput(trimWhitespace).map { input =>
+        val scanned = Scanner.scan(input)
+
+        val errors = scanned.filter(_.kind == TokenKind.Error)
+        // non-empty inputs should parse to non-empty outputs
+        assert(input.isEmpty || scanned.nonEmpty) &&
+        assert(errors.isEmpty)
       }
     }
   }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/generative/negative/PreludeParserNegativeTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/generative/negative/PreludeParserNegativeTests.scala
@@ -4,5 +4,5 @@ import playground.smithyql.Prelude
 import playground.smithyql.parser.ParserSuite
 
 object PreludeParserNegativeTests extends ParserSuite {
-  loadNegativeParserTests[Prelude]("prelude", trimWhitespace = true)
+  loadNegativeParserTests[Prelude]("prelude", trimWhitespace = true, invalidTokens = false)
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/Diffs.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/Diffs.scala
@@ -1,0 +1,12 @@
+package playground.smithyql.parser.v2
+
+import com.softwaremill.diffx.Diff
+import playground.smithyql.parser.v2.scanner.Token
+import playground.smithyql.parser.v2.scanner.TokenKind
+
+object Diffs {
+
+  implicit val tokenKindDiff: Diff[TokenKind] = Diff.derived
+  implicit val tokenDiff: Diff[Token] = Diff.derived
+
+}

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerExampleTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerExampleTests.scala
@@ -1,0 +1,119 @@
+package playground.smithyql.parser.v2
+
+import playground.smithyql.parser.v2.scanner.TokenKind._
+import weaver._
+
+object ScannerExampleTests extends SimpleIOSuite with ScannerSuite {
+  scanTest(
+    explicitName = "Real file 1",
+    input =
+      """use service demo.smithy#DemoService
+        |
+        |// CreateSubscription {
+        |//   subscription: {
+        |//     id: "subscription_id",
+        |//     name: "name",
+        |//     createdAt: "2020-04-01T00:00:00Z",
+        |//   },
+        |// }
+        |CreateHero {
+        |  hero: {
+        |    good: // bgasdfasldf
+        |      {
+        |        howGood: 10,
+        |      },
+        |  },
+        |  intSet: [
+        |    1,
+        |    2,
+        |    1,
+        |  ],
+        |}
+        |""".stripMargin,
+  )(
+    List(
+      KW_USE("use"),
+      SPACE(" "),
+      KW_SERVICE("service"),
+      SPACE(" "),
+      IDENT("demo"),
+      DOT("."),
+      IDENT("smithy"),
+      HASH("#"),
+      IDENT("DemoService"),
+      NEWLINE("\n\n"),
+      COMMENT("// CreateSubscription {"),
+      NEWLINE("\n"),
+      COMMENT("//   subscription: {"),
+      NEWLINE("\n"),
+      COMMENT("//     id: \"subscription_id\","),
+      NEWLINE("\n"),
+      COMMENT("//     name: \"name\","),
+      NEWLINE("\n"),
+      COMMENT("//     createdAt: \"2020-04-01T00:00:00Z\","),
+      NEWLINE("\n"),
+      COMMENT("//   },"),
+      NEWLINE("\n"),
+      COMMENT("// }"),
+      NEWLINE("\n"),
+      IDENT("CreateHero"),
+      SPACE(" "),
+      LBR("{"),
+      NEWLINE("\n"),
+      SPACE("  "),
+      IDENT("hero"),
+      COLON(":"),
+      SPACE(" "),
+      LBR("{"),
+      NEWLINE("\n"),
+      SPACE("    "),
+      IDENT("good"),
+      COLON(":"),
+      SPACE(" "),
+      COMMENT("// bgasdfasldf"),
+      NEWLINE("\n"),
+      SPACE("      "),
+      LBR("{"),
+      NEWLINE("\n"),
+      SPACE("        "),
+      IDENT("howGood"),
+      COLON(":"),
+      SPACE(" "),
+      LIT_NUMBER("10"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("      "),
+      RBR("}"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("  "),
+      RBR("}"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("  "),
+      IDENT("intSet"),
+      COLON(":"),
+      SPACE(" "),
+      LB("["),
+      NEWLINE("\n"),
+      SPACE("    "),
+      LIT_NUMBER("1"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("    "),
+      LIT_NUMBER("2"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("    "),
+      LIT_NUMBER("1"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("  "),
+      RB("]"),
+      COMMA(","),
+      NEWLINE("\n"),
+      RBR("}"),
+      NEWLINE("\n"),
+    )
+  )
+}

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerSuite.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerSuite.scala
@@ -1,0 +1,72 @@
+package playground.smithyql.parser.v2
+
+import cats.effect.IO
+import cats.implicits._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import playground.Assertions
+import playground.smithyql.parser.v2.scanner.Scanner
+import playground.smithyql.parser.v2.scanner.Token
+import weaver._
+
+import Diffs._
+import Scanner.scan
+
+trait ScannerSuite { self: IOSuite =>
+
+  protected def arbTests(
+    name: TestName
+  )(
+    withArb: Arbitrary[String] => IO[Expectations]
+  ): Unit = {
+
+    val sampleStringGen = Gen.oneOf(
+      Gen.alphaStr,
+      Gen.alphaNumStr,
+      Gen.asciiPrintableStr,
+      Gen.identifier,
+      Gen.oneOf(List(' ', '\n', '\t', '\r', '\f', '\b')).map(_.toString),
+    )
+
+    val arbString: Arbitrary[String] = Arbitrary {
+      Gen.listOf(sampleStringGen).map(_.mkString)
+    }
+
+    test(name)(withArb(Arbitrary.arbString))
+    test(name.copy(name = name.name + " (prepared input)"))(withArb(arbString))
+  }
+
+  protected def scanTest(
+    input: String,
+    explicitName: TestName = "",
+  )(
+    expected: List[Token]
+  )(
+    implicit loc: SourceLocation
+  ): Unit =
+    pureTest(
+      if (explicitName.name.nonEmpty)
+        explicitName
+      else
+        "Scan string: " + sanitize(input)
+    ) {
+      Assertions.assertNoDiff(scan(input), expected)
+    }
+
+  // Runs scanTest by first rendering the expected tokens to a string, then scanning it to get them back.
+  // If the output is not the same as the input, the test fails.
+  // While it's guaranteed that rendering tokens to text produces scannable code (everything is scannable),
+  // due to ambiguities in the scanner it's not guaranteed that the output will be the same as the input - hence the need to test.
+  protected def scanTestReverse(
+    explicitName: String
+  )(
+    expected: List[Token]
+  )(
+    implicit loc: SourceLocation
+  ): Unit = scanTest(expected.foldMap(_.text), explicitName)(expected)
+
+  protected def sanitize(
+    text: String
+  ) = text.replace(" ", "·").replace("\n", "↵")
+
+}

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -9,6 +9,7 @@ import playground.Assertions
 import playground.smithyql.parser.v2.scanner.Scanner
 import playground.smithyql.parser.v2.scanner.Token
 import playground.smithyql.parser.v2.scanner.TokenKind
+import playground.smithyql.parser.v2.scanner.TokenKind._
 import weaver._
 import weaver.scalacheck.Checkers
 
@@ -348,6 +349,125 @@ object ScannerTests extends SimpleIOSuite with Checkers {
   )(
     List(
       TokenKind.LIT_STRING("\"hello\nworld\"")
+    )
+  )
+
+  // real files
+
+  scanTest(
+    explicitName = "Real file 1",
+    input =
+      """use service demo.smithy#DemoService
+        |
+        |// CreateSubscription {
+        |//   subscription: {
+        |//     id: "subscription_id",
+        |//     name: "name",
+        |//     createdAt: "2020-04-01T00:00:00Z",
+        |//   },
+        |// }
+        |CreateHero {
+        |  hero: {
+        |    good: // bgasdfasldf
+        |      {
+        |        howGood: 10,
+        |      },
+        |  },
+        |  intSet: [
+        |    1,
+        |    2,
+        |    1,
+        |  ],
+        |}
+        |""".stripMargin,
+  )(
+    List(
+      TokenKind.KW_USE("use"),
+      TokenKind.SPACE(" "),
+      TokenKind.KW_SERVICE("service"),
+      TokenKind.SPACE(" "),
+      TokenKind.IDENT("demo"),
+      TokenKind.DOT("."),
+      TokenKind.IDENT("smithy"),
+      TokenKind.HASH("#"),
+      TokenKind.IDENT("DemoService"),
+      TokenKind.NEWLINE("\n\n"),
+      TokenKind.COMMENT("// CreateSubscription {"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//   subscription: {"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//     id: \"subscription_id\","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//     name: \"name\","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//     createdAt: \"2020-04-01T00:00:00Z\","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//   },"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("// }"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.IDENT("CreateHero"),
+      TokenKind.SPACE(" "),
+      TokenKind.LBR("{"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("  "),
+      TokenKind.IDENT("hero"),
+      TokenKind.COLON(":"),
+      TokenKind.SPACE(" "),
+      TokenKind.LBR("{"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("    "),
+      TokenKind.IDENT("good"),
+      TokenKind.COLON(":"),
+      TokenKind.SPACE(" "),
+      TokenKind.COMMENT("// bgasdfasldf"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("      "),
+      TokenKind.LBR("{"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("        "),
+      TokenKind.IDENT("howGood"),
+      TokenKind.COLON(":"),
+      TokenKind.SPACE(" "),
+      // bug: should be number
+      TokenKind.Error("10"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("      "),
+      TokenKind.RBR("}"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("  "),
+      TokenKind.RBR("}"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("  "),
+      TokenKind.IDENT("intSet"),
+      TokenKind.COLON(":"),
+      TokenKind.SPACE(" "),
+      TokenKind.LB("["),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("    "),
+      // bug: should be a number
+      TokenKind.Error("1"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("    "),
+      // bug: should be a number
+      TokenKind.Error("2"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("    "),
+      // bug: should be a number
+      TokenKind.Error("1"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE("  "),
+      TokenKind.RB("]"),
+      TokenKind.COMMA(","),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.RBR("}"),
+      TokenKind.NEWLINE("\n"),
     )
   )
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -88,31 +88,31 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     text: String
   ) = text.replace(" ", "·").replace("\n", "↵")
 
-  scanTest("{")(List(TokenKind.LBR("{")))
-  scanTest("}")(List(TokenKind.RBR("}")))
-  scanTest("[")(List(TokenKind.LB("[")))
-  scanTest("]")(List(TokenKind.RB("]")))
-  scanTest(".")(List(TokenKind.DOT(".")))
-  scanTest(",")(List(TokenKind.COMMA(",")))
-  scanTest("#")(List(TokenKind.HASH("#")))
-  scanTest(":")(List(TokenKind.COLON(":")))
-  scanTest("=")(List(TokenKind.EQ("=")))
-  scanTest("a")(List(TokenKind.IDENT("a")))
-  scanTest("use")(List(TokenKind.KW_USE("use")))
-  scanTest("service")(List(TokenKind.KW_SERVICE("service")))
-  scanTest("null")(List(TokenKind.KW_NULL("null")))
-  scanTest("true")(List(TokenKind.KW_BOOLEAN("true")))
-  scanTest("false")(List(TokenKind.KW_BOOLEAN("false")))
+  scanTest("{")(List(LBR("{")))
+  scanTest("}")(List(RBR("}")))
+  scanTest("[")(List(LB("[")))
+  scanTest("]")(List(RB("]")))
+  scanTest(".")(List(DOT(".")))
+  scanTest(",")(List(COMMA(",")))
+  scanTest("#")(List(HASH("#")))
+  scanTest(":")(List(COLON(":")))
+  scanTest("=")(List(EQ("=")))
+  scanTest("a")(List(IDENT("a")))
+  scanTest("use")(List(KW_USE("use")))
+  scanTest("service")(List(KW_SERVICE("service")))
+  scanTest("null")(List(KW_NULL("null")))
+  scanTest("true")(List(KW_BOOLEAN("true")))
+  scanTest("false")(List(KW_BOOLEAN("false")))
   // todo: number, string
 
   // idents
-  scanTest("abcdef")(List(TokenKind.IDENT("abcdef")))
+  scanTest("abcdef")(List(IDENT("abcdef")))
 
   scanTest(
     "hello_world"
   )(
     List(
-      TokenKind.IDENT("hello_world")
+      IDENT("hello_world")
     )
   )
 
@@ -120,41 +120,41 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     "helloworld123"
   )(
     List(
-      TokenKind.IDENT("helloworld123")
+      IDENT("helloworld123")
     )
   )
 
   scanTest(explicitName = "Identifier similar to a keyword - prefix", input = "notfalse")(
     List(
-      TokenKind.IDENT("notfalse")
+      IDENT("notfalse")
     )
   )
 
   scanTest(explicitName = "Identifier similar to a keyword - suffix", input = "falsely")(
     List(
-      TokenKind.IDENT("falsely")
+      IDENT("falsely")
     )
   )
 
   // whitespace
-  scanTest(" ")(List(TokenKind.SPACE(" ")))
-  scanTest("\n")(List(TokenKind.NEWLINE("\n")))
+  scanTest(" ")(List(SPACE(" ")))
+  scanTest("\n")(List(NEWLINE("\n")))
 
   // contiguous whitespace of all kinds
   // notably newlines are grouped together separately from other whitespace
-  scanTest("  \r \r \n\n")(List(TokenKind.SPACE("  \r \r "), TokenKind.NEWLINE("\n\n")))
+  scanTest("  \r \r \n\n")(List(SPACE("  \r \r "), NEWLINE("\n\n")))
   scanTest("  \n\n  \n ")(
     List(
-      TokenKind.SPACE("  "),
-      TokenKind.NEWLINE("\n\n"),
-      TokenKind.SPACE("  "),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE(" "),
+      SPACE("  "),
+      NEWLINE("\n\n"),
+      SPACE("  "),
+      NEWLINE("\n"),
+      SPACE(" "),
     )
   )
 
   // comments
-  scanTest("// hello 123 foo bar --")(List(TokenKind.COMMENT("// hello 123 foo bar --")))
+  scanTest("// hello 123 foo bar --")(List(COMMENT("// hello 123 foo bar --")))
 
   scanTest(
     explicitName = "Scan multiple line-comments",
@@ -163,9 +163,9 @@ object ScannerTests extends SimpleIOSuite with Checkers {
         |//world""".stripMargin,
   )(
     List(
-      TokenKind.COMMENT("//hello"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//world"),
+      COMMENT("//hello"),
+      NEWLINE("\n"),
+      COMMENT("//world"),
     )
   )
 
@@ -173,11 +173,11 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     "hello world //this is a comment"
   )(
     List(
-      TokenKind.IDENT("hello"),
-      TokenKind.SPACE(" "),
-      TokenKind.IDENT("world"),
-      TokenKind.SPACE(" "),
-      TokenKind.COMMENT("//this is a comment"),
+      IDENT("hello"),
+      SPACE(" "),
+      IDENT("world"),
+      SPACE(" "),
+      COMMENT("//this is a comment"),
     )
   )
 
@@ -186,16 +186,16 @@ object ScannerTests extends SimpleIOSuite with Checkers {
   scanTest(
     explicitName = "Error tokens for input that doesn't match any other token",
     input = "🤷*%$^@-+?",
-  )(List(TokenKind.Error("🤷*%$^@-+?")))
+  )(List(Error("🤷*%$^@-+?")))
 
   scanTest(
     explicitName = "Error tokens mixed between other tokens",
     input = "hello@world",
   )(
     List(
-      TokenKind.IDENT("hello"),
-      TokenKind.Error("@"),
-      TokenKind.IDENT("world"),
+      IDENT("hello"),
+      Error("@"),
+      IDENT("world"),
     )
   )
 
@@ -204,24 +204,24 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     input = "hello@world-this?is=an<example",
   )(
     List(
-      TokenKind.IDENT("hello"),
-      TokenKind.Error("@"),
-      TokenKind.IDENT("world"),
-      TokenKind.Error("-"),
-      TokenKind.IDENT("this"),
-      TokenKind.Error("?"),
-      TokenKind.IDENT("is"),
-      TokenKind.EQ("="),
-      TokenKind.IDENT("an"),
-      TokenKind.Error("<"),
-      TokenKind.IDENT("example"),
+      IDENT("hello"),
+      Error("@"),
+      IDENT("world"),
+      Error("-"),
+      IDENT("this"),
+      Error("?"),
+      IDENT("is"),
+      EQ("="),
+      IDENT("an"),
+      Error("<"),
+      IDENT("example"),
     )
   )
 
   scanTest(explicitName = "Error tokens before a multi-char keyword", input = "--false")(
     List(
-      TokenKind.Error("--"),
-      TokenKind.KW_BOOLEAN("false"),
+      Error("--"),
+      KW_BOOLEAN("false"),
     )
   )
 
@@ -231,29 +231,29 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     "many tokens of punctuation and idents mixed with error nodes and comments"
   )(
     List(
-      TokenKind.LBR("{"),
-      TokenKind.IDENT("foo"),
-      TokenKind.RBR("}"),
-      TokenKind.LB("["),
-      TokenKind.IDENT("bar"),
-      TokenKind.RB("]"),
-      TokenKind.DOT("."),
-      TokenKind.IDENT("baz"),
-      TokenKind.COMMA(","),
-      TokenKind.IDENT("xx"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.HASH("#"),
-      TokenKind.COLON(":"),
-      TokenKind.EQ("="),
-      TokenKind.IDENT("abc123def"),
-      TokenKind.SPACE(" "),
-      TokenKind.IDENT("ghe"),
-      TokenKind.Error("--"),
-      TokenKind.IDENT("eef"),
-      TokenKind.SPACE(" "),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//hello"),
-      TokenKind.NEWLINE("\n"),
+      LBR("{"),
+      IDENT("foo"),
+      RBR("}"),
+      LB("["),
+      IDENT("bar"),
+      RB("]"),
+      DOT("."),
+      IDENT("baz"),
+      COMMA(","),
+      IDENT("xx"),
+      NEWLINE("\n"),
+      HASH("#"),
+      COLON(":"),
+      EQ("="),
+      IDENT("abc123def"),
+      SPACE(" "),
+      IDENT("ghe"),
+      Error("--"),
+      IDENT("eef"),
+      SPACE(" "),
+      NEWLINE("\n"),
+      COMMENT("//hello"),
+      NEWLINE("\n"),
     )
   )
 
@@ -266,25 +266,25 @@ object ScannerTests extends SimpleIOSuite with Checkers {
         |null """.stripMargin,
   )(
     List(
-      TokenKind.IDENT("hello"),
-      TokenKind.SPACE(" "),
-      TokenKind.KW_USE("use"),
-      TokenKind.SPACE(" "),
-      TokenKind.KW_SERVICE("service"),
-      TokenKind.SPACE(" "),
-      TokenKind.IDENT("foo"),
-      TokenKind.SPACE(" "),
-      TokenKind.COMMENT("//bar"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE(" "),
-      TokenKind.KW_BOOLEAN("true"),
-      TokenKind.SPACE(" "),
-      TokenKind.COMMENT("//one"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//two"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.KW_NULL("null"),
-      TokenKind.SPACE(" "),
+      IDENT("hello"),
+      SPACE(" "),
+      KW_USE("use"),
+      SPACE(" "),
+      KW_SERVICE("service"),
+      SPACE(" "),
+      IDENT("foo"),
+      SPACE(" "),
+      COMMENT("//bar"),
+      NEWLINE("\n"),
+      SPACE(" "),
+      KW_BOOLEAN("true"),
+      SPACE(" "),
+      COMMENT("//one"),
+      NEWLINE("\n"),
+      COMMENT("//two"),
+      NEWLINE("\n"),
+      KW_NULL("null"),
+      SPACE(" "),
     )
   )
 
@@ -293,7 +293,7 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     "\"hello world\""
   )(
     List(
-      TokenKind.LIT_STRING("\"hello world\"")
+      LIT_STRING("\"hello world\"")
     )
   )
 
@@ -302,7 +302,7 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     input = "\"hello world",
   )(
     List(
-      TokenKind.LIT_STRING("\"hello world")
+      LIT_STRING("\"hello world")
     )
   )
 
@@ -311,10 +311,10 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     input = "\"hello world\", \"foo bar\"",
   )(
     List(
-      TokenKind.LIT_STRING("\"hello world\""),
-      TokenKind.COMMA(","),
-      TokenKind.SPACE(" "),
-      TokenKind.LIT_STRING("\"foo bar\""),
+      LIT_STRING("\"hello world\""),
+      COMMA(","),
+      SPACE(" "),
+      LIT_STRING("\"foo bar\""),
     )
   )
 
@@ -323,10 +323,10 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     input = "\"hello world\", \"foo bar",
   )(
     List(
-      TokenKind.LIT_STRING("\"hello world\""),
-      TokenKind.COMMA(","),
-      TokenKind.SPACE(" "),
-      TokenKind.LIT_STRING("\"foo bar"),
+      LIT_STRING("\"hello world\""),
+      COMMA(","),
+      SPACE(" "),
+      LIT_STRING("\"foo bar"),
     )
   )
 
@@ -335,11 +335,11 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     input = "\"hello world, \"foo bar\"",
   )(
     List(
-      TokenKind.LIT_STRING("\"hello world, \""),
-      TokenKind.IDENT("foo"),
-      TokenKind.SPACE(" "),
-      TokenKind.IDENT("bar"),
-      TokenKind.LIT_STRING("\""),
+      LIT_STRING("\"hello world, \""),
+      IDENT("foo"),
+      SPACE(" "),
+      IDENT("bar"),
+      LIT_STRING("\""),
     )
   )
 
@@ -348,7 +348,7 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     input = "\"hello\nworld\"",
   )(
     List(
-      TokenKind.LIT_STRING("\"hello\nworld\"")
+      LIT_STRING("\"hello\nworld\"")
     )
   )
 
@@ -382,92 +382,92 @@ object ScannerTests extends SimpleIOSuite with Checkers {
         |""".stripMargin,
   )(
     List(
-      TokenKind.KW_USE("use"),
-      TokenKind.SPACE(" "),
-      TokenKind.KW_SERVICE("service"),
-      TokenKind.SPACE(" "),
-      TokenKind.IDENT("demo"),
-      TokenKind.DOT("."),
-      TokenKind.IDENT("smithy"),
-      TokenKind.HASH("#"),
-      TokenKind.IDENT("DemoService"),
-      TokenKind.NEWLINE("\n\n"),
-      TokenKind.COMMENT("// CreateSubscription {"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//   subscription: {"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//     id: \"subscription_id\","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//     name: \"name\","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//     createdAt: \"2020-04-01T00:00:00Z\","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("//   },"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.COMMENT("// }"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.IDENT("CreateHero"),
-      TokenKind.SPACE(" "),
-      TokenKind.LBR("{"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("  "),
-      TokenKind.IDENT("hero"),
-      TokenKind.COLON(":"),
-      TokenKind.SPACE(" "),
-      TokenKind.LBR("{"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("    "),
-      TokenKind.IDENT("good"),
-      TokenKind.COLON(":"),
-      TokenKind.SPACE(" "),
-      TokenKind.COMMENT("// bgasdfasldf"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("      "),
-      TokenKind.LBR("{"),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("        "),
-      TokenKind.IDENT("howGood"),
-      TokenKind.COLON(":"),
-      TokenKind.SPACE(" "),
+      KW_USE("use"),
+      SPACE(" "),
+      KW_SERVICE("service"),
+      SPACE(" "),
+      IDENT("demo"),
+      DOT("."),
+      IDENT("smithy"),
+      HASH("#"),
+      IDENT("DemoService"),
+      NEWLINE("\n\n"),
+      COMMENT("// CreateSubscription {"),
+      NEWLINE("\n"),
+      COMMENT("//   subscription: {"),
+      NEWLINE("\n"),
+      COMMENT("//     id: \"subscription_id\","),
+      NEWLINE("\n"),
+      COMMENT("//     name: \"name\","),
+      NEWLINE("\n"),
+      COMMENT("//     createdAt: \"2020-04-01T00:00:00Z\","),
+      NEWLINE("\n"),
+      COMMENT("//   },"),
+      NEWLINE("\n"),
+      COMMENT("// }"),
+      NEWLINE("\n"),
+      IDENT("CreateHero"),
+      SPACE(" "),
+      LBR("{"),
+      NEWLINE("\n"),
+      SPACE("  "),
+      IDENT("hero"),
+      COLON(":"),
+      SPACE(" "),
+      LBR("{"),
+      NEWLINE("\n"),
+      SPACE("    "),
+      IDENT("good"),
+      COLON(":"),
+      SPACE(" "),
+      COMMENT("// bgasdfasldf"),
+      NEWLINE("\n"),
+      SPACE("      "),
+      LBR("{"),
+      NEWLINE("\n"),
+      SPACE("        "),
+      IDENT("howGood"),
+      COLON(":"),
+      SPACE(" "),
       // bug: should be number
-      TokenKind.Error("10"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("      "),
-      TokenKind.RBR("}"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("  "),
-      TokenKind.RBR("}"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("  "),
-      TokenKind.IDENT("intSet"),
-      TokenKind.COLON(":"),
-      TokenKind.SPACE(" "),
-      TokenKind.LB("["),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("    "),
+      Error("10"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("      "),
+      RBR("}"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("  "),
+      RBR("}"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("  "),
+      IDENT("intSet"),
+      COLON(":"),
+      SPACE(" "),
+      LB("["),
+      NEWLINE("\n"),
+      SPACE("    "),
       // bug: should be a number
-      TokenKind.Error("1"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("    "),
+      Error("1"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("    "),
       // bug: should be a number
-      TokenKind.Error("2"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("    "),
+      Error("2"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("    "),
       // bug: should be a number
-      TokenKind.Error("1"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.SPACE("  "),
-      TokenKind.RB("]"),
-      TokenKind.COMMA(","),
-      TokenKind.NEWLINE("\n"),
-      TokenKind.RBR("}"),
-      TokenKind.NEWLINE("\n"),
+      Error("1"),
+      COMMA(","),
+      NEWLINE("\n"),
+      SPACE("  "),
+      RB("]"),
+      COMMA(","),
+      NEWLINE("\n"),
+      RBR("}"),
+      NEWLINE("\n"),
     )
   )
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -1,0 +1,171 @@
+package playground.smithyql.parser.v2
+
+import cats.effect.IO
+import cats.implicits._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import playground.smithyql.parser.v2.scanner.Scanner
+import playground.smithyql.parser.v2.scanner.Token
+import playground.smithyql.parser.v2.scanner.TokenKind
+import weaver._
+import weaver.scalacheck.Checkers
+
+import Scanner.scan
+
+object ScannerTests extends SimpleIOSuite with Checkers {
+
+  def arbTests(
+    name: TestName
+  )(
+    withArb: Arbitrary[String] => IO[Expectations]
+  ): Unit = {
+
+    val sampleStringGen = Gen.oneOf(
+      Gen.alphaStr,
+      Gen.alphaNumStr,
+      Gen.asciiPrintableStr,
+      Gen.identifier,
+      Gen.oneOf(List(' ', '\n', '\t', '\r', '\f', '\b')).map(_.toString),
+    )
+
+    val arbString: Arbitrary[String] = Arbitrary {
+      Gen.listOf(sampleStringGen).map(_.mkString)
+    }
+
+    test(name)(withArb(Arbitrary.arbString))
+    test(name.copy(name = name.name + " (prepared input)"))(withArb(arbString))
+  }
+
+  arbTests("Any string input scans successfully") { implicit arbString =>
+    forall { (s: String) =>
+      scan(s): Unit
+      success
+    }
+  }
+
+  arbTests("Scanning is lossless") { implicit arbString =>
+    forall { (s: String) =>
+      assert.eql(scan(s).foldMap(_.text), s)
+    }
+  }
+
+  private def scanTest(
+    input: String,
+    explicitName: String = "",
+  )(
+    expected: List[Token]
+  ): Unit =
+    pureTest(
+      if (explicitName.nonEmpty)
+        explicitName
+      else
+        "Scan string: " + sanitize(input)
+    ) {
+      assert.eql(expected, scan(input))
+    }
+
+  private def sanitize(
+    text: String
+  ) = text.replace(" ", "·").replace("\n", "↵")
+
+  scanTest("{")(List(TokenKind.LBR("{")))
+  scanTest("}")(List(TokenKind.RBR("}")))
+  scanTest("[")(List(TokenKind.LB("[")))
+  scanTest("]")(List(TokenKind.RB("]")))
+  scanTest(".")(List(TokenKind.DOT(".")))
+  scanTest(",")(List(TokenKind.COMMA(",")))
+  scanTest("#")(List(TokenKind.HASH("#")))
+  scanTest("=")(List(TokenKind.EQ("=")))
+  scanTest("a")(List(TokenKind.IDENT("a")))
+
+  // idents
+  scanTest("abcdef")(List(TokenKind.IDENT("abcdef")))
+
+  scanTest(
+    "hello_world"
+  )(
+    List(
+      TokenKind.IDENT("hello_world")
+    )
+  )
+
+  scanTest(
+    "helloworld123"
+  )(
+    List(
+      TokenKind.IDENT("helloworld123")
+    )
+  )
+
+  // whitespace
+  scanTest(" ")(List(TokenKind.SPACE(" ")))
+  scanTest("\n")(List(TokenKind.NEWLINE("\n")))
+
+  // contiguous whitespace of all kinds
+  // notably newlines are grouped together separately from other whitespace
+  scanTest("  \r \r \n\n")(List(TokenKind.SPACE("  \r \r "), TokenKind.NEWLINE("\n\n")))
+  scanTest("  \n\n  \n ")(
+    List(
+      TokenKind.SPACE("  "),
+      TokenKind.NEWLINE("\n\n"),
+      TokenKind.SPACE("  "),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE(" "),
+    )
+  )
+
+  // comments
+  scanTest("// hello 123 foo bar --")(List(TokenKind.COMMENT("// hello 123 foo bar --")))
+
+  scanTest(
+    explicitName = "Scan multiple line-comments",
+    input =
+      """//hello
+        |//world""".stripMargin,
+  )(
+    List(
+      TokenKind.COMMENT("//hello"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//world"),
+    )
+  )
+
+  scanTest(
+    "hello world //this is a comment"
+  )(
+    List(
+      TokenKind.IDENT("hello"),
+      TokenKind.SPACE(" "),
+      TokenKind.IDENT("world"),
+      TokenKind.SPACE(" "),
+      TokenKind.COMMENT("//this is a comment"),
+    )
+  )
+
+  // errors
+
+  scanTest(
+    explicitName = "Error tokens for input that doesn't match any other token",
+    input = "🤷*%$^@-+?",
+  )(List(TokenKind.Error("🤷*%$^@-+?")))
+
+  scanTest(
+    explicitName = "Error tokens mixed between other tokens",
+    input = "hello@world-this?is=an<example",
+  )(
+    List(
+      TokenKind.IDENT("hello"),
+      TokenKind.Error("@"),
+      TokenKind.IDENT("world"),
+      TokenKind.Error("-"),
+      TokenKind.IDENT("this"),
+      TokenKind.Error("?"),
+      TokenKind.IDENT("is"),
+      TokenKind.EQ("="),
+      TokenKind.IDENT("an"),
+      TokenKind.Error("<"),
+      TokenKind.IDENT("example"),
+    )
+  )
+
+}

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -287,4 +287,59 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     )
   )
 
+  // string literals
+  scanTest(
+    "\"hello world\""
+  )(
+    List(
+      TokenKind.LIT_STRING("\"hello world\"")
+    )
+  )
+
+  scanTest(
+    explicitName = "String literal that never ends",
+    input = "\"hello world",
+  )(
+    List(
+      TokenKind.LIT_STRING("\"hello world")
+    )
+  )
+
+  scanTest(
+    explicitName = "Multiple string literals",
+    input = "\"hello world\", \"foo bar\"",
+  )(
+    List(
+      TokenKind.LIT_STRING("\"hello world\""),
+      TokenKind.COMMA(","),
+      TokenKind.SPACE(" "),
+      TokenKind.LIT_STRING("\"foo bar\""),
+    )
+  )
+
+  scanTest(
+    explicitName = "Multiple string literals, second one not closed",
+    input = "\"hello world\", \"foo bar",
+  )(
+    List(
+      TokenKind.LIT_STRING("\"hello world\""),
+      TokenKind.COMMA(","),
+      TokenKind.SPACE(" "),
+      TokenKind.LIT_STRING("\"foo bar"),
+    )
+  )
+
+  scanTest(
+    explicitName = "Multiple string literals, first one not closed",
+    input = "\"hello world, \"foo bar\"",
+  )(
+    List(
+      TokenKind.LIT_STRING("\"hello world, \""),
+      TokenKind.IDENT("foo"),
+      TokenKind.SPACE(" "),
+      TokenKind.IDENT("bar"),
+      TokenKind.LIT_STRING("\""),
+    )
+  )
+
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -342,4 +342,12 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     )
   )
 
+  scanTest(
+    explicitName = "String literal, multi-line (parity test)",
+    input = "\"hello\nworld\"",
+  )(
+    List(
+      TokenKind.LIT_STRING("\"hello\nworld\"")
+    )
+  )
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -255,4 +255,36 @@ object ScannerTests extends SimpleIOSuite with Checkers {
       TokenKind.NEWLINE("\n"),
     )
   )
+
+  scanTest(
+    explicitName = "whitespace and comments around keyword",
+    input =
+      """hello use service foo //bar
+        | true //one
+        |//two
+        |null """.stripMargin,
+  )(
+    List(
+      TokenKind.IDENT("hello"),
+      TokenKind.SPACE(" "),
+      TokenKind.KW_USE("use"),
+      TokenKind.SPACE(" "),
+      TokenKind.KW_SERVICE("service"),
+      TokenKind.SPACE(" "),
+      TokenKind.IDENT("foo"),
+      TokenKind.SPACE(" "),
+      TokenKind.COMMENT("//bar"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.SPACE(" "),
+      TokenKind.KW_BOOLEAN("true"),
+      TokenKind.SPACE(" "),
+      TokenKind.COMMENT("//one"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.COMMENT("//two"),
+      TokenKind.NEWLINE("\n"),
+      TokenKind.KW_NULL("null"),
+      TokenKind.SPACE(" "),
+    )
+  )
+
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -169,4 +169,36 @@ object ScannerTests extends SimpleIOSuite with Checkers {
     )
   )
 
+  // complex cases
+
+  scanTest(
+    explicitName = "many tokens of punctuation and idents mixed with error nodes and comments",
+    input =
+      """{foo}[bar].baz,xx#:=abc123def ghe--eef //hello
+        |""".stripMargin,
+  )(
+    List(
+      TokenKind.LBR("{"),
+      TokenKind.IDENT("foo"),
+      TokenKind.RBR("}"),
+      TokenKind.LB("["),
+      TokenKind.IDENT("bar"),
+      TokenKind.RB("]"),
+      TokenKind.DOT("."),
+      TokenKind.IDENT("baz"),
+      TokenKind.COMMA(","),
+      TokenKind.IDENT("xx"),
+      TokenKind.HASH("#"),
+      TokenKind.COLON(":"),
+      TokenKind.EQ("="),
+      TokenKind.IDENT("abc123def"),
+      TokenKind.SPACE(" "),
+      TokenKind.IDENT("ghe"),
+      TokenKind.Error("--"),
+      TokenKind.IDENT("eef"),
+      TokenKind.SPACE(" "),
+      TokenKind.COMMENT("//hello"),
+      TokenKind.NEWLINE("\n"),
+    )
+  )
 }

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -97,6 +97,12 @@ object ScannerTests extends SimpleIOSuite with Checkers {
   scanTest(":")(List(TokenKind.COLON(":")))
   scanTest("=")(List(TokenKind.EQ("=")))
   scanTest("a")(List(TokenKind.IDENT("a")))
+  scanTest("use")(List(TokenKind.KW_USE("use")))
+  scanTest("service")(List(TokenKind.KW_SERVICE("service")))
+  scanTest("null")(List(TokenKind.KW_NULL("null")))
+  scanTest("true")(List(TokenKind.KW_BOOLEAN("true")))
+  scanTest("false")(List(TokenKind.KW_BOOLEAN("false")))
+  // todo: number, string
 
   // idents
   scanTest("abcdef")(List(TokenKind.IDENT("abcdef")))
@@ -114,6 +120,18 @@ object ScannerTests extends SimpleIOSuite with Checkers {
   )(
     List(
       TokenKind.IDENT("helloworld123")
+    )
+  )
+
+  scanTest(explicitName = "Identifier similar to a keyword - prefix", input = "notfalse")(
+    List(
+      TokenKind.IDENT("notfalse")
+    )
+  )
+
+  scanTest(explicitName = "Identifier similar to a keyword - suffix", input = "falsely")(
+    List(
+      TokenKind.IDENT("falsely")
     )
   )
 
@@ -196,6 +214,13 @@ object ScannerTests extends SimpleIOSuite with Checkers {
       TokenKind.IDENT("an"),
       TokenKind.Error("<"),
       TokenKind.IDENT("example"),
+    )
+  )
+
+  scanTest(explicitName = "Error tokens before a multi-char keyword", input = "--false")(
+    List(
+      TokenKind.Error("--"),
+      TokenKind.KW_BOOLEAN("false"),
     )
   )
 

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -75,6 +75,7 @@ object ScannerTests extends SimpleIOSuite with Checkers {
   scanTest(".")(List(TokenKind.DOT(".")))
   scanTest(",")(List(TokenKind.COMMA(",")))
   scanTest("#")(List(TokenKind.HASH("#")))
+  scanTest(":")(List(TokenKind.COLON(":")))
   scanTest("=")(List(TokenKind.EQ("=")))
   scanTest("a")(List(TokenKind.IDENT("a")))
 

--- a/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
+++ b/modules/parser/src/test/scala/playground/smithyql/parser/v2/ScannerTests.scala
@@ -64,6 +64,16 @@ object ScannerTests extends SimpleIOSuite with Checkers {
       assert.eql(expected, scan(input))
     }
 
+  // Runs scanTest by first rendering the expected tokens to a string, then scanning it to get them back.
+  // If the output is not the same as the input, the test fails.
+  // While it's guaranteed that rendering tokens to text produces scannable code (everything is scannable),
+  // due to ambiguities in the scanner it's not guaranteed that the output will be the same as the input - hence the need to test.
+  private def scanTestReverse(
+    explicitName: String
+  )(
+    expected: List[Token]
+  ): Unit = scanTest(expected.foldMap(_.text), explicitName)(expected)
+
   private def sanitize(
     text: String
   ) = text.replace(" ", "·").replace("\n", "↵")
@@ -171,11 +181,8 @@ object ScannerTests extends SimpleIOSuite with Checkers {
 
   // complex cases
 
-  scanTest(
-    explicitName = "many tokens of punctuation and idents mixed with error nodes and comments",
-    input =
-      """{foo}[bar].baz,xx#:=abc123def ghe--eef //hello
-        |""".stripMargin,
+  scanTestReverse(
+    "many tokens of punctuation and idents mixed with error nodes and comments"
   )(
     List(
       TokenKind.LBR("{"),
@@ -188,6 +195,7 @@ object ScannerTests extends SimpleIOSuite with Checkers {
       TokenKind.IDENT("baz"),
       TokenKind.COMMA(","),
       TokenKind.IDENT("xx"),
+      TokenKind.NEWLINE("\n"),
       TokenKind.HASH("#"),
       TokenKind.COLON(":"),
       TokenKind.EQ("="),
@@ -197,6 +205,7 @@ object ScannerTests extends SimpleIOSuite with Checkers {
       TokenKind.Error("--"),
       TokenKind.IDENT("eef"),
       TokenKind.SPACE(" "),
+      TokenKind.NEWLINE("\n"),
       TokenKind.COMMENT("//hello"),
       TokenKind.NEWLINE("\n"),
     )

--- a/modules/plugin-core/src/main/scala/playground/plugins/PlaygroundPlugin.scala
+++ b/modules/plugin-core/src/main/scala/playground/plugins/PlaygroundPlugin.scala
@@ -5,7 +5,6 @@ import org.http4s.client.Client
 import smithy4s.Service
 import smithy4s.UnsupportedProtocolError
 import smithy4s.http4s.SimpleProtocolBuilder
-import smithy4s.kinds._
 
 import java.util.ServiceLoader
 import scala.jdk.CollectionConverters._
@@ -36,7 +35,7 @@ trait SimpleHttpBuilder {
   def client[Alg[_[_, _, _, _, _]], F[_]: Concurrent](
     service: Service[Alg],
     backend: Client[F],
-  ): Either[UnsupportedProtocolError, FunctorAlgebra[Alg, F]]
+  ): Either[UnsupportedProtocolError, service.Impl[F]]
 
 }
 
@@ -50,8 +49,7 @@ object SimpleHttpBuilder {
       def client[Alg[_[_, _, _, _, _]], F[_]: Concurrent](
         service: Service[Alg],
         backend: Client[F],
-      ): Either[UnsupportedProtocolError, FunctorAlgebra[Alg, F]] =
-        builder(service).client(backend).use
+      ): Either[UnsupportedProtocolError, service.Impl[F]] = builder(service).client(backend).make
 
     }
 


### PR DESCRIPTION
Adds a scanner for all language tokens.

The design is inspired by [rowan](https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/syntax.md), although most of that will be visible in the parser stage, which will come in the future.

This scanner is:
- total: there is no input that should fail to produce tokens
- lossless: you can render the tokens back to the original code they were produced from. Note that full utf-8 isn't explicitly supported, so codepoints that don't fit in a char may break here. However, preliminary testing with property-based testing hasn't shown any cases that would fail to parse and re-render.
- full fidelity: the tokens include comments and whitespace.
	-	worth noting, newlines are treated specifically: normally whitespace tokens consist of any number of white characters, but newlines form their own tokens. See tests for examples, but the main reason this is being done is to make sync points easier in the parser (by relying on newline tokens).

- Scanner
	- [x] Single-char tokens (punctuation)
		- [x] missed: colons
	- [x] Identifiers
	- [x] Single-line comments
	- [x] Multi-character tokens (keywords)
		- [x] Keywords after comments, after whitespace etc.
	- [x] String literals (unescaped, multi-line: consistent with current parser)
	- [x] Numeric literals (full JSON number syntax)
		- Using Cats Parse for this, we can switch to a custom implementation later on. I'm not gonna waste hours of my life just to avoid using a third-party library ;P
	- [x] Boolean/null literals
	- [x] Parity testing
		- [x] include scanner test in all generative tests
		- [x] test for a non-empty list of non-error tokens
		- [x] any error tokens in valid inputs should be reported as test failures
	- [x] support arbitrary utf-8 codepoints?
		- Maybe later. For now, not a priority.