### PR TITLE
Revert "Move BaseUri middleware"

### DIFF
--- a/modules/core/src/main/scala/playground/OperationRunner.scala
+++ b/modules/core/src/main/scala/playground/OperationRunner.scala
@@ -13,9 +13,11 @@ import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
+import cats.effect.implicits.*
 import cats.effect.std
 import cats.syntax.all.*
 import fs2.compression.Compression
+import org.http4s.Uri
 import org.http4s.client.Client
 import playground.plugins.PlaygroundPlugin
 import playground.plugins.SimpleHttpBuilder
@@ -115,15 +117,39 @@ object OperationRunner {
 
   }
 
+  // https://github.com/kubukoz/smithy-playground/issues/158
+  def dynamicBaseUri[F[_]: MonadCancelThrow](
+    getUri: F[Uri]
+  ): Client[F] => Client[F] =
+    client =>
+      Client[F] { req =>
+        getUri.toResource.flatMap { uri =>
+          client.run(
+            req.withUri(
+              req
+                .uri
+                .copy(
+                  scheme = uri.scheme,
+                  authority = uri.authority,
+                  // prefixing with uri.path
+                  path = uri.path.addSegments(req.uri.path.segments),
+                )
+            )
+          )
+        }
+      }
+
   def forSchemaIndex[F[_]: StdlibRuntime: Async: Compression: std.Console](
     dsi: DynamicSchemaIndex,
     client: Client[F],
+    baseUri: F[Uri],
     awsEnv: Resource[F, AwsEnvironment[F]],
     plugins: List[PlaygroundPlugin],
   ): Map[QualifiedIdentifier, Resolver[F]] = forServices(
     services = dsi.allServices.toList,
     getSchema = dsi.getSchema,
     client = client,
+    baseUri = baseUri,
     awsEnv = awsEnv,
     plugins = plugins,
   )
@@ -132,6 +158,7 @@ object OperationRunner {
     services: List[DynamicSchemaIndex.ServiceWrapper],
     getSchema: ShapeId => Option[Schema[?]],
     client: Client[F],
+    baseUri: F[Uri],
     awsEnv: Resource[F, AwsEnvironment[F]],
     plugins: List[PlaygroundPlugin],
   ): Map[QualifiedIdentifier, Resolver[F]] =
@@ -140,6 +167,7 @@ object OperationRunner {
         OperationRunner.forService[svc.Alg, F](
           svc.service,
           client,
+          baseUri,
           awsEnv,
           getSchema,
           plugins,
@@ -173,6 +201,7 @@ object OperationRunner {
   def forService[Alg[_[_, _, _, _, _]], F[_]: StdlibRuntime: Async: Compression: std.Console](
     service: Service[Alg],
     client: Client[F],
+    baseUri: F[Uri],
     awsEnv: Resource[F, AwsEnvironment[F]],
     schemaIndex: ShapeId => Option[Schema[?]],
     plugins: List[PlaygroundPlugin],
@@ -195,7 +224,11 @@ object OperationRunner {
         builder
           .client(
             service,
-            client,
+            dynamicBaseUri[F](
+              baseUri.flatTap { uri =>
+                std.Console[F].println(s"Using base URI: $uri")
+              }
+            ).apply(client),
           )
           .leftMap(e => Issue.InvalidProtocol(e.protocolTag.id, serviceProtocols))
           .map(service.toPolyFunction(_))

--- a/modules/language-support/src/test/scala/playground/language/DiagnosticProviderTests.scala
+++ b/modules/language-support/src/test/scala/playground/language/DiagnosticProviderTests.scala
@@ -85,6 +85,7 @@ object DiagnosticProviderTests extends SimpleIOSuite {
           services = services,
           getSchema = _ => None,
           client = client,
+          baseUri = IO.stub,
           awsEnv = Resource.eval(IO.stub: IO[AwsEnvironment[IO]]),
           plugins = Nil,
         ),

--- a/modules/lsp/src/main/scala/playground/lsp/LanguageClient.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/LanguageClient.scala
@@ -6,6 +6,7 @@ import cats.effect.kernel.Async
 import cats.syntax.all.*
 import cats.tagless.Derive
 import cats.tagless.FunctorK
+import cats.tagless.catsTaglessApplyKForIdK
 import cats.tagless.implicits.*
 import cats.~>
 import com.google.gson.JsonElement

--- a/modules/lsp/src/main/scala/playground/lsp/LanguageServer.scala
+++ b/modules/lsp/src/main/scala/playground/lsp/LanguageServer.scala
@@ -9,6 +9,7 @@ import cats.parse.LocationMap
 import cats.syntax.all.*
 import cats.tagless.Derive
 import cats.tagless.FunctorK
+import cats.tagless.catsTaglessApplyKForIdK
 import cats.tagless.implicits.*
 import cats.~>
 import com.google.gson.JsonElement


### PR DESCRIPTION
Reverts kubukoz/smithy-playground#515

The change inadvertently changed behavior of plugins and AWS clients: if you set a custom URI that doesn't come from configuration, configuration will override it anyway, with no way of opting out (null values aren't accepted).