### PR TITLE
Better way to get source locations

### DIFF
--- a/modules/core/src/main/scala/playground/smithyql/syntax.scala
+++ b/modules/core/src/main/scala/playground/smithyql/syntax.scala
@@ -24,4 +24,8 @@ object syntax {
 
   }
 
+  extension (qi: QualifiedIdentifier) {
+    def toShapeId: ShapeId = ShapeId(qi.renderNamespace, qi.selection)
+  }
+
 }

--- a/modules/core/src/test/scala/playground/smithyql/CompilationTests.scala
+++ b/modules/core/src/test/scala/playground/smithyql/CompilationTests.scala
@@ -94,14 +94,18 @@ object CompilationTests extends SimpleIOSuite with Checkers {
     services: List[DynamicSchemaIndex.ServiceWrapper]
   )(
     q: SourceFile[WithSource]
-  ): IorThrow[List[CompiledInput]] = playground
-    .FileCompiler
-    .instance(
-      PreludeCompiler.instance[CompilationError.InIorNel](ServiceIndex.fromServices(services)),
-      OperationCompiler.fromServices(services),
-    )
-    .mapK(CompilationFailed.wrapK)
-    .compile(q)
+  ): IorThrow[List[CompiledInput]] = {
+    val serviceIndex = ServiceIndex.fromServices(services)
+
+    playground
+      .FileCompiler
+      .instance(
+        PreludeCompiler.instance[CompilationError.InIorNel](serviceIndex),
+        OperationCompiler.fromServices(services, serviceIndex),
+      )
+      .mapK(CompilationFailed.wrapK)
+      .compile(q)
+  }
 
   val dynamicModel: DynamicSchemaIndex = DynamicModel.discover()
 

--- a/modules/language-support/src/main/scala/playground/language/CompletionProvider.scala
+++ b/modules/language-support/src/main/scala/playground/language/CompletionProvider.scala
@@ -33,19 +33,19 @@ trait CompletionProvider {
 object CompletionProvider {
 
   def forSchemaIndex(
-    dsi: DynamicSchemaIndex
-  ): CompletionProvider = forServices(dsi.allServices.toList)
+    dsi: DynamicSchemaIndex,
+    serviceIndex: ServiceIndex,
+  ): CompletionProvider = forServices(dsi.allServices.toList, serviceIndex)
 
   def forServices(
-    allServices: List[DynamicSchemaIndex.ServiceWrapper]
+    allServices: List[DynamicSchemaIndex.ServiceWrapper],
+    serviceIndex: ServiceIndex,
   ): CompletionProvider = {
     // long-term, it'd be nice to get rid of this (too low level)
     val servicesById =
       allServices.map { service =>
         QualifiedIdentifier.forService(service.service) -> service
       }.toMap
-
-    val serviceIndex = ServiceIndex.fromServices(allServices)
 
     // Completions for the service's operations.
     // Uses a list of imported services (use clauses) to determine whether a new use clause is needed to use this service's operations.

--- a/modules/language-support/src/test/scala/playground/language/CodeLensProviderTests.scala
+++ b/modules/language-support/src/test/scala/playground/language/CodeLensProviderTests.scala
@@ -32,11 +32,13 @@ object CodeLensProviderTests extends FunSuite {
 
   private val services = List(wrapService(RandomGen))
 
+  private val serviceIndex = ServiceIndex.fromServices(services)
+
   private val provider = CodeLensProvider.instance(
     FileCompiler
       .instance(
-        PreludeCompiler.instance[CompilationError.InIorNel](ServiceIndex.fromServices(services)),
-        OperationCompiler.fromServices(services),
+        PreludeCompiler.instance[CompilationError.InIorNel](serviceIndex),
+        OperationCompiler.fromServices(services, serviceIndex),
       )
       // this shouldn't be here (it's a responsibility of file compiler)
       .mapK(CompilationFailed.wrapK),

--- a/modules/language-support/src/test/scala/playground/language/CompletionProviderTests.scala
+++ b/modules/language-support/src/test/scala/playground/language/CompletionProviderTests.scala
@@ -4,6 +4,7 @@ import demo.smithy.DemoService
 import demo.smithy.DemoServiceGen
 import demo.smithy.DeprecatedServiceGen
 import playground.Assertions.*
+import playground.ServiceIndex
 import playground.ServiceUtils.*
 import playground.language.Diffs.given
 import playground.smithyql.Position
@@ -20,7 +21,10 @@ object CompletionProviderTests extends SimpleIOSuite {
 
   pureTest("completing empty file - one service exists") {
     val random = wrapService(RandomGen)
-    val provider = CompletionProvider.forServices(List(random))
+    val provider = CompletionProvider.forServices(
+      List(random),
+      serviceIndex = ServiceIndex.fromServices(List(random)),
+    )
 
     val result = provider.provide(
       "",
@@ -48,7 +52,10 @@ object CompletionProviderTests extends SimpleIOSuite {
     val clock = wrapService(ClockGen)
     val random = wrapService(RandomGen)
 
-    val provider = CompletionProvider.forServices(List(clock, random))
+    val provider = CompletionProvider.forServices(
+      List(clock, random),
+      serviceIndex = ServiceIndex.fromServices(List(clock, random)),
+    )
 
     val result = provider.provide(
       "",
@@ -76,7 +83,10 @@ object CompletionProviderTests extends SimpleIOSuite {
   pureTest("completing existing operation name doesn't insert struct") {
     val service = wrapService(RandomGen)
 
-    val provider = CompletionProvider.forServices(List(service))
+    val provider = CompletionProvider.forServices(
+      List(service),
+      serviceIndex = ServiceIndex.fromServices(List(service)),
+    )
 
     val input = """playground.std#Random.NextUUID {}""".stripMargin
     val result = provider.provide(
@@ -99,7 +109,10 @@ object CompletionProviderTests extends SimpleIOSuite {
   pureTest("completing existing use clause") {
     val service = wrapService(DemoServiceGen)
 
-    val provider = CompletionProvider.forServices(List(service))
+    val provider = CompletionProvider.forServices(
+      List(service),
+      serviceIndex = ServiceIndex.fromServices(List(service)),
+    )
 
     val result = provider.provide(
       """use service a#B
@@ -121,7 +134,8 @@ object CompletionProviderTests extends SimpleIOSuite {
     "the file has a use clause - completing operations shows results from that clause, but also others"
   ) {
     val provider = CompletionProvider.forServices(
-      List(wrapService(ClockGen), wrapService(RandomGen))
+      List(wrapService(ClockGen), wrapService(RandomGen)),
+      serviceIndex = ServiceIndex.fromServices(List(wrapService(ClockGen), wrapService(RandomGen))),
     )
     val input =
       """use service playground.std#Clock
@@ -152,7 +166,10 @@ object CompletionProviderTests extends SimpleIOSuite {
 
   locally {
     pureTest("completing empty file - one (deprecated) service exists") {
-      val provider = CompletionProvider.forServices(List(wrapService(DeprecatedServiceGen)))
+      val provider = CompletionProvider.forServices(
+        List(wrapService(DeprecatedServiceGen)),
+        serviceIndex = ServiceIndex.fromServices(List(wrapService(DeprecatedServiceGen))),
+      )
 
       val result = provider
         .provide(
@@ -165,7 +182,10 @@ object CompletionProviderTests extends SimpleIOSuite {
     }
 
     pureTest("completing use clause - one (deprecated) service exists") {
-      val provider = CompletionProvider.forServices(List(wrapService(DeprecatedServiceGen)))
+      val provider = CompletionProvider.forServices(
+        List(wrapService(DeprecatedServiceGen)),
+        serviceIndex = ServiceIndex.fromServices(List(wrapService(DeprecatedServiceGen))),
+      )
 
       val result = provider
         .provide(
@@ -181,7 +201,10 @@ object CompletionProviderTests extends SimpleIOSuite {
   pureTest("completing operation - multiple services available") {
     val clock = wrapService(ClockGen)
     val random = wrapService(RandomGen)
-    val provider = CompletionProvider.forServices(List(clock, random))
+    val provider = CompletionProvider.forServices(
+      List(clock, random),
+      serviceIndex = ServiceIndex.fromServices(List(clock, random)),
+    )
 
     val input =
       """use service playground.std#Clock
@@ -212,7 +235,10 @@ object CompletionProviderTests extends SimpleIOSuite {
   }
 
   pureTest("completing operation examples - input examples get used") {
-    val provider = CompletionProvider.forServices(List(wrapService(DemoService)))
+    val provider = CompletionProvider.forServices(
+      List(wrapService(DemoService)),
+      serviceIndex = ServiceIndex.fromServices(List(wrapService(DemoService))),
+    )
 
     val input =
       s"""use service ${DemoService.id}

--- a/modules/language-support/src/test/scala/playground/language/DiagnosticProviderTests.scala
+++ b/modules/language-support/src/test/scala/playground/language/DiagnosticProviderTests.scala
@@ -96,11 +96,13 @@ object DiagnosticProviderTests extends SimpleIOSuite {
     Interpreters.stdlib[IO],
   )
 
+  private val serviceIndex = ServiceIndex.fromServices(services)
+
   private val provider = DiagnosticProvider.instance(
     compiler = FileCompiler
       .instance(
-        PreludeCompiler.instance[CompilationError.InIorNel](ServiceIndex.fromServices(services)),
-        OperationCompiler.fromServices(services),
+        PreludeCompiler.instance[CompilationError.InIorNel](serviceIndex),
+        OperationCompiler.fromServices(services, serviceIndex),
       )
       .mapK(CompilationFailed.wrapK),
     fileRunner = FileRunner.instance(
@@ -110,7 +112,7 @@ object DiagnosticProviderTests extends SimpleIOSuite {
           getSchema = _ => None,
           interpreters = interpreters,
         ),
-        ServiceIndex.fromServices(services),
+        serviceIndex,
       )
     ),
   )

--- a/modules/lsp-kernel/src/main/scala/playground/lsp/BuildLoader.scala
+++ b/modules/lsp-kernel/src/main/scala/playground/lsp/BuildLoader.scala
@@ -7,7 +7,7 @@ import fs2.io.file.Path
 import playground.PlaygroundConfig
 import playground.Uri
 import playground.language.TextDocumentProvider
-import smithy4s.dynamic.DynamicSchemaIndex
+import software.amazon.smithy.model.Model
 
 trait BuildLoader[F[_]] {
 
@@ -15,9 +15,9 @@ trait BuildLoader[F[_]] {
     workspaceFolders: List[Uri]
   ): F[BuildLoader.Loaded]
 
-  def buildSchemaIndex(
+  def buildModel(
     info: BuildLoader.Loaded
-  ): F[DynamicSchemaIndex]
+  ): F[Model]
 
 }
 
@@ -86,9 +86,9 @@ object BuildLoader {
       }
         .adaptErr(new Exception("Failed to load build configuration", _))
 
-      def buildSchemaIndex(
+      def buildModel(
         loaded: BuildLoader.Loaded
-      ): F[DynamicSchemaIndex] = {
+      ): F[Model] = {
         // This has to be lazy, because for the default, "no imports" config, the file path points to the filesystem root.
         lazy val workspaceBase = loaded
           .configFilePath
@@ -105,10 +105,9 @@ object BuildLoader {
         for {
           specs <- filterImports(rawImportPaths)
           model <- loadModel(specs, loaded.config)
-          dsi = DynamicSchemaIndex.loadModel(model)
-        } yield dsi
+        } yield model
       }
-        .adaptErr(new Exception("Failed to load schema index", _))
+        .adaptErr(new Exception("Failed to load model", _))
 
       private def loadModel(
         specs: Set[Path],

--- a/modules/lsp-kernel/src/main/scala/playground/lsp/ModelLoader.scala
+++ b/modules/lsp-kernel/src/main/scala/playground/lsp/ModelLoader.scala
@@ -3,17 +3,10 @@ package playground.lsp
 import coursierapi.*
 import playground.PlaygroundConfig
 import playground.lsp.buildinfo.BuildInfo
-import playground.std.PlaygroundSourceLocation
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.loader.ModelAssembler
 import software.amazon.smithy.model.loader.ModelDiscovery
 import software.amazon.smithy.model.loader.ModelManifestException
-import software.amazon.smithy.model.node.Node
-import software.amazon.smithy.model.shapes.AbstractShapeBuilder
-import software.amazon.smithy.model.shapes.Shape
-import software.amazon.smithy.model.shapes.ShapeId as SmithyShapeId
-import software.amazon.smithy.model.traits.DynamicTrait
-import software.amazon.smithy.model.transform.ModelTransformer
 
 import java.io.File
 import java.net.URL
@@ -55,38 +48,6 @@ object ModelLoader {
     .pipe(addFileImports(specs))
     .assemble()
     .unwrap()
-    .pipe(addSourceLocationHints)
-
-  private def addSourceLocationHints(model: Model): Model = {
-    val sourceLocTraitId = {
-      val shp = PlaygroundSourceLocation.id
-      SmithyShapeId.from(shp.show)
-    }
-
-    ModelTransformer
-      .create()
-      .mapShapes(
-        model,
-        shp => {
-          val b = Shape.shapeToBuilder(shp): AbstractShapeBuilder[?, ? <: Shape]
-
-          val loc = shp.getSourceLocation()
-
-          b.addTrait(
-            new DynamicTrait(
-              sourceLocTraitId,
-              Node
-                .objectNode()
-                .withMember("file", loc.getFilename())
-                .withMember("line", loc.getLine())
-                .withMember("column", loc.getColumn()),
-            )
-          )
-
-          b.build()
-        },
-      )
-  }
 
   // Credits: myself, in smithy4s 0.17.5
   private def addJarModels(

--- a/modules/lsp-kernel/src/main/scala/playground/lsp/ServerBuilder.scala
+++ b/modules/lsp-kernel/src/main/scala/playground/lsp/ServerBuilder.scala
@@ -117,7 +117,11 @@ object ServerBuilder {
           implicit val reporter: CommandResultReporter[F] = rep
 
           LanguageServer
-            .instance[F](dsi, FileRunner.instance(OperationRunner.merge[F](runners, serviceIndex)))
+            .instance[F](
+              dsi = dsi,
+              serviceIndex = serviceIndex,
+              runner = FileRunner.instance(OperationRunner.merge[F](runners, serviceIndex)),
+            )
         }
     }
   }

--- a/modules/protocol4s/src/main/smithy/std.smithy
+++ b/modules/protocol4s/src/main/smithy/std.smithy
@@ -39,15 +39,3 @@ operation CurrentTimestamp {
         value: Timestamp
     }
 }
-
-@trait
-structure PlaygroundSourceLocation {
-    @required
-    file: String
-
-    @required
-    line: Integer
-
-    @required
-    column: Integer
-}


### PR DESCRIPTION
In #597, I used a model transformation to capture source locations as traits/hints - after checking with a larger model and a profiler I realized this is completely inefficient. Instead, we'll get the locations only of the shapes we're touching in the index. This should allow for adding some laziness if that becomes a bottleneck again.