### PR TITLE
Set dependency cooldown as a precaution against avoidable supply chain attacks

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,3 +3,6 @@ updates.fileExtensions = [
   "smithy-build.json",
   "modules/lsp/src/test/resources/test-workspaces/default/smithy-build.json"
 ]
+updates.cooldown = {
+  minimumAge = "7 days"
+}


### PR DESCRIPTION


Context: https://github.com/scala-steward-org/scala-steward/pull/3762